### PR TITLE
Only include certmanager if it's enabled & parameterise ingress class

### DIFF
--- a/charts/buildbuddy/Chart.yaml
+++ b/charts/buildbuddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Open Source
 name: buildbuddy
-version: 0.0.19 # Chart version
+version: 0.0.20 # Chart version
 appVersion: 1.6.1 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy/requirements.yaml
+++ b/charts/buildbuddy/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   alias: certmanager
   version: 0.16.1
   repository: https://charts.jetstack.io
-  condition: ingress.enabled
+  condition: certmanager.enabled

--- a/charts/buildbuddy/templates/ingress.yaml
+++ b/charts/buildbuddy/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}

--- a/charts/buildbuddy/values.yaml
+++ b/charts/buildbuddy/values.yaml
@@ -72,6 +72,7 @@ service:
 
 ingress:
   enabled: false
+  class: "nginx"
 
   ## To enable SSL, either enable certmanager below or specify a
   ## clusterIssuer that's already installed in the cluster.


### PR DESCRIPTION
Hi there 👋🏻 I _think_ this may be a copy/paste mistake in the `requirements.yaml`, but if it's intentionally set to `ingress.enabled`, apologies for taking your bandwidth!

Also parameterises `ingress.class` to allow the easy use of different ingress types