### PR TITLE
Add extraPodSpec for extending pod definitions

### DIFF
--- a/charts/buildbuddy/templates/deployment.yaml
+++ b/charts/buildbuddy/templates/deployment.yaml
@@ -106,3 +106,6 @@ spec:
         {{- if .Values.extraVolumes -}}
         {{ .Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
+      {{- if .Values.extraPodSpec }}
+      {{- .Values.extraPodSpec | toYaml | nindent 6 }}
+      {{- end }}


### PR DESCRIPTION
Hi again 👋🏻 we were hoping to have some affinities and nodeSelectors to our BuildBuddy instance, and were hoping you'd be happy to extend the chart to allow for that.

This felt like a nicer approach than adding each thing individually, but if you'd prefer a PR in that direction happy to do either approach!

Example usage:

```yaml
extraPodSpec:
  nodeSelector:
    node.kubernetes.io/instance-type: c5.4xlarge

  tolerations:
    - key: "target"
      operator: "Equal"
      value: "abcdef"
      effect: "NoSchedule"
```