### PR TITLE
Update the executor charts

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.80 # Chart version
+version: 0.0.81 # Chart version
 appVersion: 2.8.3 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/_helpers.tpl
+++ b/charts/buildbuddy-executor/templates/_helpers.tpl
@@ -30,16 +30,3 @@ Create chart name and version as used by the chart label.
 {{- define "buildbuddy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
-
-{{/*
-Return the appropriate apiVersion for ingress. Based on
-1) Helm Version (.Capabilities has been changed in v3)
-2) Kubernetes Version
-*/}}
-{{- define "buildbuddy.ingress.apiVersion" -}}
-{{- if semverCompare ">=1.4-0, <1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-"extensions/v1beta1"
-{{- else if semverCompare "^1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-"networking.k8s.io/v1beta1"
-{{- end -}}
-{{- end -}}


### PR DESCRIPTION
The executor doesn't use Ingress, this just keeps the helpers in line with the other versions from #9 and #10