### PR TITLE
Fix the redefined selector in buildbuddy-redis

### DIFF
--- a/charts/buildbuddy-redis/templates/service.yaml
+++ b/charts/buildbuddy-redis/templates/service.yaml
@@ -22,8 +22,4 @@ spec:
       protocol: 'TCP'
       port: {{ .Values.service.internalRedisPort }}
       targetPort: {{ .Values.service.internalRedisPort }}
-  selector:
-    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
 


### PR DESCRIPTION
I found that selector is redefined in the buildbuddy-redis charts