### PR TITLE
Update open-source ingress ApiVersion

### DIFF
--- a/charts/buildbuddy/Chart.yaml
+++ b/charts/buildbuddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Open Source
 name: buildbuddy
-version: 0.0.94 # Chart version
+version: 0.0.95 # Chart version
 appVersion: 2.9.9 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy/templates/ingress.yaml
+++ b/charts/buildbuddy/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ingress.enabled }}
-apiVersion: {{ include "buildbuddy.ingress.apiVersion" . }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "buildbuddy.fullname" . }}-grpc
@@ -33,7 +33,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: grpc
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -72,7 +72,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: http
   {{ if .Values.ingress.sslEnabled }}
   tls:


### PR DESCRIPTION
This is just a quick fix for the apiVersion in the `ingress.yaml` following this recent change #10 to the open-source version.

Tried upgrading BB from 0.32 to the latest, and noticed since the apiVersion ref was taken out of the named template, upgrading would complain with `error calling include: template: no template "buildbuddy.ingress.apiVersion"`