### PR TITLE
Remove app.kubernetes.io/managed-by selectors

### DIFF
--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -26,7 +26,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy-enterprise/templates/service.yaml
+++ b/charts/buildbuddy-enterprise/templates/service.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   type: {{ .Values.service.type }}
   ports:
     - name: http
@@ -63,7 +62,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   clusterIP: None
   ports:
     - name: http

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy-redis/templates/deployment.yaml
+++ b/charts/buildbuddy-redis/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy-redis/templates/service.yaml
+++ b/charts/buildbuddy-redis/templates/service.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   type: {{ .Values.service.type }}
   ports:
     - name: redis

--- a/charts/buildbuddy/templates/deployment.yaml
+++ b/charts/buildbuddy/templates/deployment.yaml
@@ -18,7 +18,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy/templates/service.yaml
+++ b/charts/buildbuddy/templates/service.yaml
@@ -15,7 +15,6 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
   type: {{ .Values.service.type }}
   ports:
     - name: http


### PR DESCRIPTION
This selector isn't really necessary, and causes issues when releasing with Spinnaker as Spinnaker overwrites the label:

> Deploy failed: The Deployment "buildbuddy-executor" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/instance":"buildbuddy", "app.kubernetes.io/managed-by":"spinnaker", "app.kubernetes.io/name":"executor", "helm.sh/chart":"executor-0.0.105", "team":"infrastructure"}: selector does not match template labels