### PR TITLE
enterprise: make ingress.class configurable

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.172 # Chart version
+version: 0.0.173 # Chart version
 appVersion: 2.12.12 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     {{- if .Values.certmanager.enabled }}
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -60,7 +60,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     nginx.ingress.kubernetes.io/server-alias: "~.*@{{ .Values.ingress.grpcHost | replace "." "\\\\." }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -104,7 +104,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -106,6 +106,7 @@ service:
 
 ingress:
   enabled: false
+  class: "nginx"
 
   ## To enable SSL, either enable certmanager below or specify a
   ## clusterIssuer that's already installed in the cluster.


### PR DESCRIPTION
Ensure that user could customize the ingress.class to other values such as "alb" or "nginx". The default "nginx" value is not changed.