### PR TITLE
executor: add missing mounts when podman is enabled

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.150 # Chart version
+version: 0.0.151 # Chart version
 appVersion: 2.12.25 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -106,6 +106,14 @@ spec:
               subPath: config.yaml
             - name: dockersock
               mountPath: /var/run/docker.sock
+            {{- if .Values.config.executor.enable_podman }}
+            - name: containerd-lib
+              mountPath: /var/lib/containerd
+            - name: containerd-run
+              mountPath: /run/containerd
+            - name: containers-lib
+              mountPath: /var/lib/containers
+            {{- end }}
             {{- if .Values.extraVolumeMounts -}}
             {{ .Values.extraVolumeMounts | toYaml | nindent 12 }}
             {{- end }}
@@ -122,6 +130,16 @@ spec:
             path: /var/run/docker.sock        
         - name: executor-data
           emptyDir: {}
+        {{- if .Values.config.executor.enable_podman }}
+        - name: containerd-lib
+          hostPath:
+            path: /var/lib/containerd
+        - name: containerd-run
+          hostPath:
+            path: /run/containerd
+        - name: containers-lib
+          emptyDir: {}
+        {{- end }}
         {{- if .Values.extraVolumes -}}
         {{ .Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
When podman is enabled, we need to mount some dedicated emptyDir volume into the Executor container so that podman could download and store container images onto these paths.