### PR TITLE
Experimenting with AWS deployment

### DIFF
--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -1,4 +1,10 @@
-{{ if .Values.ingress.enabled }}
+{{ if and
+  (.Values.ingress.enabled)
+  (ne .Values.ingress.class "alb")
+}}
+#########
+# NGINX #
+#########
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -42,7 +48,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: grpc
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -87,7 +93,7 @@ spec:
             backend:
               service:
                 name: {{ include "buildbuddy.name" . }}
-                port: 
+                port:
                   name: grpc
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -126,7 +132,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: http
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -134,4 +140,127 @@ spec:
       hosts:
         - {{ .Values.ingress.httpHost }}
   {{ end }}
+{{ end }}
+{{ if and
+  (.Values.ingress.enabled)
+  (and
+    (eq .Values.ingress.class "alb")
+    (eq .Values.service.type "NodePort")
+  )
+}}
+#######
+# ALB #
+#######
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "buildbuddy.name" . }}
+            port: 
+              name: grpc
+    {{- if not .Values.testing }}
+    host: {{ .Values.ingress.grpcHost }}
+    {{- end }}
+  tls:
+    - secretName: {{ .Values.ingress.grpcHost }}-tls
+      hosts:
+        - {{ .Values.ingress.grpcHost }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-at-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "buildbuddy.name" . }}
+                port: 
+                  name: grpc
+  tls:
+    - secretName: {{ .Values.ingress.grpcHost }}-tls
+      hosts:
+        - {{ .Values.ingress.grpcHost }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-http
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "HTTP1"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "buildbuddy.name" . }}
+            port: 
+              name: http
+    {{- if not .Values.testing }}
+    host: {{ .Values.ingress.grpcHost }}
+    {{- end }}
+  tls:
+    - secretName: {{ .Values.ingress.httpHost }}-tls
+      hosts:
+        - {{ .Values.ingress.httpHost }}
 {{ end }}

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -163,6 +163,21 @@ ingress:
   #       prometheus.io/scrape: "true"
   #       prometheus.io/port: "10254"
 
+  ## AWS's LoadBalancer(ALB) Controller
+  ## Documentation: https://kubernetes-sigs.github.io/aws-load-balancer-controller
+  ## Configuration steps:
+  ##   - Install `aws-load-balancer-controller` into your cluster
+  ##   - Disable nginx-controller with `ingress.controller.enabled: false`
+  ##   - Enable ingress by setting `ingress.enabled: true`
+  ##   - Configure `ingress.class: "alb"` for the controller to aware of the Ingress
+  ##   - Depending on what type is your Service, the chart will provision different things:
+  ##     + LoadBalancer: ALB controller will provision a legacy Elastic Load Balancer corresponding to your Service directly.
+  ##     + NodePort: ALB controller will provision a set of Load Balancer corresponding to your Ingress configurations.
+  ##       Note: Serving GRPC requests through ALB requires an SSL connection so you need to set `ingress.alb.certificateArn`
+  ##             to a valid certificate ARN on AWS. Example below.
+  # alb:
+  #   certificateArn: "arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxx"
+
 certmanager:
   ## Before enabling certmanager, make sure to install the CRDs on your cluster with:
   ## kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml

--- a/examples/aws/.gitignore
+++ b/examples/aws/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+*.tfstate*

--- a/examples/aws/.terraform.lock.hcl
+++ b/examples/aws/.terraform.lock.hcl
@@ -1,0 +1,142 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.50.0"
+  constraints = ">= 2.23.0, >= 3.40.0, >= 3.72.0, >= 3.73.0, >= 4.0.0, >= 4.47.0, ~> 4.50.0"
+  hashes = [
+    "h1:jYbnOsQkAQ2O2eiZU3B5LACcEz0eoqX4cZNEjzMar8Q=",
+    "zh:03a5795ea9ed3eb80e0d5e0c5234dc76455aa4437e5546399127939c24a60973",
+    "zh:24556a15eb4a69955857b3a52322f099e68031e6f9a3df2cfdb6f6351cc4885e",
+    "zh:2c2a18f3da3c06f9da5f2aca485d0b324c8510f2afb70fc1470bcb31485db061",
+    "zh:37f194e62f7b433b7235b6e4f6954dd9352554ad044007802d3fa9b80a7a7331",
+    "zh:4591157be7c8ec8160186a74789c44f214c7142f400e2c147b710e25abe15be0",
+    "zh:53e0f9ca106a9691c20535500cdcf9e4255993536e19ef2fc4c6353bfc7e2e5b",
+    "zh:54eb4c288adfafe866b3b1fcc0550ddd025f59843cfa6dd3310fed85c766b950",
+    "zh:56e887eba5bb6dd60eb2c72d09eba34232b59a0c83ac1f3693e4064ebd2af02f",
+    "zh:57858a160b5dc3c454697798d38e528662c9234f9ab1742f6c5b3bd0414e0578",
+    "zh:6ce0a31d9b1bf2dc069414c7aeae0a660aa60b58a59e97a1c575786b120a0104",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b70d22fa41bb30536fb1be5242701b19b0be8bb50ec6ba03bb5396be3cdac8c6",
+    "zh:ece8726967858c44a5ae458f7a8438e825128d356fbf1893d41ccb172bb263d9",
+    "zh:f0f2a8be772add8d0cdadf77fda7ed1c0dfbbeab9801a0d2d8820148653aa8f4",
+    "zh:fc93015058e9592810aa4b3e7834df1717ba8d6aec4679997d16c030c885d6fc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.2.0"
+  constraints = ">= 2.0.0, ~> 2.2.0"
+  hashes = [
+    "h1:Id6dDkpuSSLbGPTdbw49bVS/7XXHu/+d7CJoGDqtk5g=",
+    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
+    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
+    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
+    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
+    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
+    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
+    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
+    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
+    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
+    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
+    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.0.3"
+  constraints = "~> 2.0.1"
+  hashes = [
+    "h1:Fwl+HUI+VvKYUNuZPb1nN9zFVtMGELJp0KrNXp58uiY=",
+    "zh:154e0aa489e474e2eeb3de94be7666133faf6fd950712a640425b2bf3a81ee95",
+    "zh:16a2be6c4b61d0c5205c63816148c7ab0c8f56a75c05e8d897fa4d5cac0c029a",
+    "zh:189e47bc723f8c29bcfe2c1638d43b8148f614ea86e642f4b50b2acb4b760224",
+    "zh:3763901d3630213002cb8c70bb24c628cd29738ff6591585250ea8636264abd6",
+    "zh:4822f85e4700ea049384523d98de0ef7d83549844b13e94bbd544cec05557a9a",
+    "zh:62c5b87b09e0051bab0b712e3ad465fd53e66f9619dbe76ee23519d1087d8a05",
+    "zh:a0a6a842b11190dd1841e98bbb74961074e7ffb95984be5cc392df9f532d803e",
+    "zh:beac4e6806e77447e1018f3404a5fbf782d20d82a0d9b4a31e9bfc7d2bbecab6",
+    "zh:e1bbaa09bf4f4a91ec7606f84d2e0200a02e7b24d045e8b5daebd87d7a75b7ce",
+    "zh:ed1e05c50212d4f57435ccdd68cfb98d8395927c316df76d1dd6509566d3aeaa",
+    "zh:fdc687e16a964bb652ddb670f6832fdead25235eca551796cfed70ec07d94931",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.16.1"
+  constraints = ">= 2.10.0, ~> 2.16.1"
+  hashes = [
+    "h1:kO/d+ZMZYM2tNMMFHZqBmVR0MeemoGnI2G2NSN92CrU=",
+    "zh:06224975f5910d41e73b35a4d5079861da2c24f9353e3ebb015fbb3b3b996b1c",
+    "zh:2bc400a8d9fe7755cca27c2551564a9e2609cfadc77f526ef855114ee02d446f",
+    "zh:3a479014187af1d0aec3a1d3d9c09551b801956fe6dd29af1186dec86712731b",
+    "zh:73fb0a69f1abdb02858b6589f7fab6d989a0f422f7ad95ed662aaa84872d3473",
+    "zh:a33852cd382cbc8e06d3f6c018b468ad809d24d912d64722e037aed1f9bf39db",
+    "zh:b533ff2214dca90296b1d22eace7eaa7e3efe5a7ae9da66a112094abc932db4f",
+    "zh:ddf74d8bb1aeb01dc2c36ef40e2b283d32b2a96db73f6daaf179fa2f10949c80",
+    "zh:e720f3a15d34e795fa9ff90bc755e838ebb4aef894aa2a423fb16dfa6d6b0667",
+    "zh:e789ae70a658800cb0a19ef7e4e9b26b5a38a92b43d1f41d64fc8bb46539cefb",
+    "zh:e8aed7dc0bd8f843d607dee5f72640dbef6835a8b1c6ea12cea5b4ec53e463f7",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb3ac4f43c8b0dfc0b0103dd0f062ea72b3a34518d4c8808e3a44c9a3dd5f024",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = "~> 3.4.3"
+  hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.4"
+  constraints = ">= 3.0.0, ~> 4.0.4"
+  hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -1,0 +1,82 @@
+# BuildBuddy Example Deployment on AWS with Terraform
+
+This is *Experimental*, DO NOT USE!
+
+
+## Getting Started
+
+1. Setup AWS CLI
+
+```
+> brew install awscli
+
+> aws configure
+```
+
+2. Export appropriate variables
+
+```
+echo 'export KUBE_CONFIG_PATH=~/.kube/config' >> ~/.zshrc
+```
+
+3. Run Terraform
+
+```
+> brew install terraform
+
+> cd bb-aws
+
+> terraform init
+
+> terraform apply
+```
+
+4. Set kubectl context
+
+```
+> aws eks list-clusters
+
+> aws eks --region $(terraform output -raw region) update-kubeconfig \
+          --name $(terraform output -raw cluster_name)
+
+# Check everything is working
+> kubectl cluster-info
+> kubectl get nodes
+> kubectl get pods
+
+# Get External URL to access BuildBuddy service
+> kubectl get service
+```
+
+5. Clean up
+
+```
+> terraform destroy
+
+# Our PVC were claimed by Helm chart, but helm does not delete PVC upon
+# reversal, so we should manually clean them up.
+#
+# See https://github.com/helm/helm/issues/5156 for more information.
+
+> aws ec2 describe-volumes
+> aws ec2 delete-volume --volume-id <vol-id>
+```
+
+
+## Known problems
+
+1. Terraform destroy got stuck at VPC
+
+   This is most likely due to some eni is still being used and cannot be destroyed.
+   Upon further investigation, it's likely that the ordering of the helm chart deletion left the EC2 Load Balancer in-place.
+   These Load Balancer, in turn, blocks the deletion of ENI and thus, blocks VPC destroy.
+   
+   Fix: Go to AWS Console and manually delete the Load Balancer
+
+1. Left over resources after Terraform destroy
+
+   It's very likely that there are left over resources that require manual clean up
+
+   For example:
+   - EBS volumes are left over helm avoids cleaning up PVC (see 'Clean up' section above)
+   - DHCP option set was automatically created with the VPC, but isn't tracked by Terraform

--- a/examples/aws/alb.tf
+++ b/examples/aws/alb.tf
@@ -1,0 +1,71 @@
+# IAM permission
+module "lb_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.10.0"
+
+  role_name                              = "eks_lb"
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-load-balancer-controller"]
+    }
+  }
+}
+
+# service account
+resource "kubernetes_service_account" "service-account" {
+  metadata {
+    name      = "aws-load-balancer-controller"
+    namespace = "kube-system"
+    labels = {
+      "app.kubernetes.io/name"      = "aws-load-balancer-controller"
+      "app.kubernetes.io/component" = "controller"
+    }
+    annotations = {
+      "eks.amazonaws.com/role-arn"               = module.lb_role.iam_role_arn
+      "eks.amazonaws.com/sts-regional-endpoints" = "true"
+    }
+  }
+}
+
+# k8s controller
+resource "helm_release" "lb" {
+  name       = "aws-load-balancer-controller"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.4.7"
+
+  namespace = "kube-system"
+
+  set {
+    name  = "region"
+    value = var.region
+  }
+
+  set {
+    name  = "vpcId"
+    value = module.vpc.vpc_id
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "false"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "clusterName"
+    value = module.eks.cluster_name
+  }
+
+  depends_on = [
+    kubernetes_service_account.service-account
+  ]
+}
+

--- a/examples/aws/buildbuddy-values.yaml
+++ b/examples/aws/buildbuddy-values.yaml
@@ -1,0 +1,22 @@
+ingress:
+  enabled: true
+  class: "alb"
+  annotations:
+    # Only need this so we can access it from public internet
+    alb.ingress.kubernetes.io/scheme: internet-facing
+  controller:
+    enabled: false
+
+testing: true
+
+mysql:
+  enabled: true
+  mysqlUser: "sampleUser"
+  mysqlPassword: "samplePassword"
+
+redis:
+  enabled: true
+
+config:
+  app:
+    build_buddy_url: "https://buildbuddy.example.com"

--- a/examples/aws/ebs.tf
+++ b/examples/aws/ebs.tf
@@ -1,0 +1,26 @@
+module "ebs_csi_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.10.0"
+
+  role_name             = "ebs-csi"
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    ex = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+module "ebs_csi_driver_controller" {
+  source  = "DrFaust92/ebs-csi-driver/kubernetes"
+  version = "3.5.0"
+
+  oidc_url = module.eks.oidc_provider
+
+
+  depends_on = [
+    null_resource.update-kubeconfig
+  ]
+}

--- a/examples/aws/eks.tf
+++ b/examples/aws/eks.tf
@@ -1,0 +1,54 @@
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+locals {
+  cluster_name = "bb-aws-eks-${random_string.suffix.result}"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.5.1"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.24"
+
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.vpc.private_subnets
+  cluster_endpoint_public_access = true
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name = "node-group-1"
+
+      instance_types = ["t3.xlarge"]
+      capacity_type  = "SPOT"
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    command     = "aws"
+  }
+}
+
+resource "null_resource" "update-kubeconfig" {
+  provisioner "local-exec" {
+    command = "aws eks --region ${var.region} update-kubeconfig --name ${module.eks.cluster_name}"
+  }
+}

--- a/examples/aws/helm.tf
+++ b/examples/aws/helm.tf
@@ -1,0 +1,25 @@
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      command     = "aws"
+    }
+  }
+}
+
+resource "helm_release" "buildbuddy" {
+  name  = "buildbuddy"
+  chart = "../../charts/buildbuddy-enterprise"
+
+  values = [
+    file("${path.module}/buildbuddy-values.yaml")
+  ]
+
+  depends_on = [
+    null_resource.update-kubeconfig
+  ]
+}

--- a/examples/aws/outputs.tf
+++ b/examples/aws/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_endpoint" {
+  description = "Endpoint for EKS control plane"
+  value       = module.eks.cluster_endpoint
+}
+
+output "region" {
+  description = "AWS region"
+  value       = var.region
+}
+
+output "cluster_name" {
+  description = "Kubernetes Cluster Name"
+  value       = module.eks.cluster_name
+}

--- a/examples/aws/terraform.tf
+++ b/examples/aws/terraform.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.50.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4.3"
+    }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0.4"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.2.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.16.1"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0.1"
+    }
+  }
+
+  required_version = "~> 1.3"
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/examples/aws/variables.tf
+++ b/examples/aws/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "eu-central-1"
+}

--- a/examples/aws/vpc.tf
+++ b/examples/aws/vpc.tf
@@ -1,0 +1,28 @@
+data "aws_availability_zones" "available" {}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.19.0"
+
+  name = "bb-aws-vpc"
+
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/elb"                      = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${local.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"             = 1
+  }
+}


### PR DESCRIPTION
We want to experiement with deploying BuildBuddy helm chart on AWS.

Initial approach includes using Terraform with EKS module and Helm provider to apply the BuildBuddy chart onto a newly provisioned EKS cluster.

We use:
- AWS's EBS CSI driver to automatically provisioning EBS volumes for k8s Persistent Volume Claims.
- AWS's LoadBalancer controller to automatically provision ALB/ELB for k8s' Service and/or Ingress.

Future works:

Subsequent steps should include swapping out components in the helm chart for AWS-native components:

- S3 for object storage
- Replace K8s MySQL with RDS
- Use AWS's ClickHouse DB

Additionally, we would want to provide additonal examples:

- Setup authentication provider
- Deploy BuildBuddy Executor
- Configure distributed cache