### PR TITLE
Ingress: support ALB

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.183 # Chart version
+version: 0.0.184 # Chart version
 appVersion: 2.12.25 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/alb.yaml
+++ b/charts/buildbuddy-enterprise/templates/alb.yaml
@@ -1,0 +1,123 @@
+{{ if and
+  (.Values.ingress.enabled)
+  (and
+    (eq .Values.ingress.class "alb")
+    (eq .Values.service.type "NodePort")
+  )
+}}
+#######
+# ALB #
+#######
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "buildbuddy.name" . }}
+            port: 
+              name: grpc
+    {{- if not .Values.testing }}
+    host: {{ .Values.ingress.grpcHost }}
+    {{- end }}
+  tls:
+    - secretName: {{ .Values.ingress.grpcHost }}-tls
+      hosts:
+        - {{ .Values.ingress.grpcHost }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-at-grpc
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ include "buildbuddy.name" . }}
+                port: 
+                  name: grpc
+  tls:
+    - secretName: {{ .Values.ingress.grpcHost }}-tls
+      hosts:
+        - {{ .Values.ingress.grpcHost }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}-http
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+  annotations:
+    kubernetes.io/ingress.class: "alb"
+
+    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    alb.ingress.kubernetes.io/backend-protocol-version: "HTTP1"
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+
+    {{- with .Values.ingress.annotations }}
+    {{- . | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "buildbuddy.name" . }}
+            port: 
+              name: http
+    {{- if not .Values.testing }}
+    host: {{ .Values.ingress.grpcHost }}
+    {{- end }}
+  tls:
+    - secretName: {{ .Values.ingress.httpHost }}-tls
+      hosts:
+        - {{ .Values.ingress.httpHost }}
+{{ end }}

--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -1,4 +1,10 @@
-{{ if .Values.ingress.enabled }}
+{{ if and
+  (.Values.ingress.enabled)
+  (ne .Values.ingress.class "alb")
+}}
+#########
+# NGINX #
+#########
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -42,7 +48,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: grpc
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -87,7 +93,7 @@ spec:
             backend:
               service:
                 name: {{ include "buildbuddy.name" . }}
-                port: 
+                port:
                   name: grpc
   {{ if .Values.ingress.sslEnabled }}
   tls:
@@ -126,7 +132,7 @@ spec:
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: http
   {{ if .Values.ingress.sslEnabled }}
   tls:

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -163,6 +163,21 @@ ingress:
   #       prometheus.io/scrape: "true"
   #       prometheus.io/port: "10254"
 
+  ## AWS's LoadBalancer(ALB) Controller
+  ## Documentation: https://kubernetes-sigs.github.io/aws-load-balancer-controller
+  ## Configuration steps:
+  ##   - Install `aws-load-balancer-controller` into your cluster
+  ##   - Disable nginx-controller with `ingress.controller.enabled: false`
+  ##   - Enable ingress by setting `ingress.enabled: true`
+  ##   - Configure `ingress.class: "alb"` for the controller to aware of the Ingress
+  ##   - Depending on what type is your Service, the chart will provision different things:
+  ##     + LoadBalancer: ALB controller will provision a legacy Elastic Load Balancer corresponding to your Service directly.
+  ##     + NodePort: ALB controller will provision a set of Load Balancer corresponding to your Ingress configurations.
+  ##       Note: Serving GRPC requests through ALB requires an SSL connection so you need to set `ingress.alb.certificateArn`
+  ##             to a valid certificate ARN on AWS. Example below.
+  # alb:
+  #   certificateArn: "arn:aws:acm:us-west-2:xxxxx:certificate/xxxxxxx"
+
 certmanager:
   ## Before enabling certmanager, make sure to install the CRDs on your cluster with:
   ## kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.crds.yaml


### PR DESCRIPTION
Add basic support for using AWS's LoadBalancer as Ingress on EKS.

This was split from https://github.com/buildbuddy-io/buildbuddy-helm/pull/40

Add support for ALB Ingress using AWS LoadBalancer Controller(1) on EKS.

(1): https://github.com/kubernetes-sigs/aws-load-balancer-controller/

---

Version bump: Patch
