### PR TITLE
executor: require privileged with podman

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.154 # Chart version
+version: 0.0.155 # Chart version
 appVersion: 2.12.29 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -119,6 +119,9 @@ spec:
             {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
+            {{- if .Values.config.executor.enable_podman }}
+            privileged: true
+            {{- end }}
             {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
       volumes:


### PR DESCRIPTION
When podman isolation type is used, our executor would run child
runner containers inside the executor container(parent) using
'podman'.

This requires the executor container to be executed with privileged.
