### PR TITLE
[charts/buildbuddy-executor] Utilize extraInitContainers value

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         {{- .Values.extraPodLabels | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.extraInitContainers }}
+      initContainers:
+      {{- .Values.extraInitContainers | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.securityContext }}
       securityContext:
       {{- .Values.securityContext | toYaml | nindent 8 }}


### PR DESCRIPTION
The extraInitContainers value was not utilized in the template. This PR makes it so that the extraInitContainers value works as expected.
