### PR TITLE
[charts/buildbuddy-executor] Only set SYS_* environment variables if they are not in the config

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -54,14 +54,18 @@ spec:
             {{- .Values.resources | toYaml | nindent 12 }}
           {{- end }}
           env:
+            {{- if not .Values.config.executor.memory_bytes }}
             - name: SYS_MEMORY_BYTES
               valueFrom:
                 resourceFieldRef:
                   resource: limits.memory
+            {{- end }}
+            {{- if not .Values.config.executor.millicpu }}
             - name: SYS_MILLICPU
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
+            {{- end }}
             - name: MY_HOSTNAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR prevents adding `SYS_MEMORY_BYTES` and `SYS_MILLICPUS` environment variables to the executor pod, if those values are set in the executor config. As documented in the executor config [here](https://www.buildbuddy.io/docs/config-all-options#buildbuddy-executor), these values should only be set either by the environment variables or the config, but not both. This PR reflects those requirements in the helm chart.
