### PR TITLE
Add ingress.controller.enabled to values.yaml

### DIFF
--- a/charts/buildbuddy/values.yaml
+++ b/charts/buildbuddy/values.yaml
@@ -88,7 +88,7 @@ ingress:
 
   ## Nginx controller
   controller:
-    enabled: false
+    enabled: true
     config:
       load-balance: "round_robin"
       ## The defaults here are low - this sets them for all servers.

--- a/charts/buildbuddy/values.yaml
+++ b/charts/buildbuddy/values.yaml
@@ -88,6 +88,7 @@ ingress:
 
   ## Nginx controller
   controller:
+    enabled: false
     config:
       load-balance: "round_robin"
       ## The defaults here are low - this sets them for all servers.


### PR DESCRIPTION
This adds the variable to values.yaml with the default behavior.

This variable is used here: https://github.com/buildbuddy-io/buildbuddy-helm/blob/65dc236db30d890fab30517cf6424384933a2b83/charts/buildbuddy/requirements.yaml#L10