### PR TITLE
Fix customExecutorCommand

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.172 # Chart version
+version: 0.0.173 # Chart version
 appVersion: 2.12.45 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -56,7 +56,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           {{- if .Values.customExecutorCommand }}
-          command: {{ .Values.customExecutorCommand }}
+          command:
+          {{- .Values.customExecutorCommand | toYaml | nindent 10}}
           {{- end }}
           {{- if not .Values.customExecutorCommand }}
           args: ["--server_type=buildbuddy-executor"]


### PR DESCRIPTION
I only tested my change to add `customExecutorCommand`, with one element in the list. When there's multiple elements in the `customExecutorCommand`, it failed. 

This fixes the issue by converting the `customExecutorCommand` to yaml in the template.
