### PR TITLE
executor: remove unused podman volumes

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.173 # Chart version
+version: 0.0.174 # Chart version
 appVersion: 2.12.45 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -126,10 +126,6 @@ spec:
               mountPath: /var/run/docker.sock
             {{- end }}
             {{- if .Values.config.executor.enable_podman }}
-            - name: containerd-lib
-              mountPath: /var/lib/containerd
-            - name: containerd-run
-              mountPath: /run/containerd
             - name: containers-lib
               mountPath: /var/lib/containers
             {{- end }}
@@ -144,6 +140,8 @@ spec:
             {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
           {{- end }}
       volumes:
+        - name: executor-data
+          emptyDir: {}
         - name: config
           secret:
             secretName: {{ include "buildbuddy.fullname" . }}-config
@@ -152,15 +150,7 @@ spec:
           hostPath:
             path: /var/run/docker.sock
         {{- end }}
-        - name: executor-data
-          emptyDir: {}
         {{- if .Values.config.executor.enable_podman }}
-        - name: containerd-lib
-          hostPath:
-            path: /var/lib/containerd
-        - name: containerd-run
-          hostPath:
-            path: /run/containerd
         - name: containers-lib
           emptyDir: {}
         {{- end }}


### PR DESCRIPTION
Removing containerd volumes as it communicates wrong information.
Podman does not require containerd to be mounted to Node's hostPath to
work. Mounting containerd paths (1) does help with debugging podman
during development however.

Move the required executor-data mount to the top of the volumes list to
improve readability.

(1): https://github.com/containerd/containerd/blob/v1.7.2/docs/ops.md#base-configuration
