### PR TITLE
enterprise/alb: include hostname in spec rule

### DIFF
--- a/charts/buildbuddy-enterprise/templates/alb.yaml
+++ b/charts/buildbuddy-enterprise/templates/alb.yaml
@@ -30,18 +30,16 @@ metadata:
     {{- end }}
 spec:
   rules:
-  - http:
+  - host: {{ .Values.ingress.grpcHost }}
+    http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: grpc
-    {{- if not .Values.testing }}
-    host: {{ .Values.ingress.grpcHost }}
-    {{- end }}
   tls:
     - secretName: {{ .Values.ingress.grpcHost }}-tls
       hosts:
@@ -75,7 +73,7 @@ spec:
             backend:
               service:
                 name: {{ include "buildbuddy.name" . }}
-                port: 
+                port:
                   name: grpc
   tls:
     - secretName: {{ .Values.ingress.grpcHost }}-tls
@@ -104,18 +102,16 @@ metadata:
     {{- end }}
 spec:
   rules:
-  - http:
+  - host: {{ .Values.ingress.httpHost }}
+    http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
             name: {{ include "buildbuddy.name" . }}
-            port: 
+            port:
               name: http
-    {{- if not .Values.testing }}
-    host: {{ .Values.ingress.grpcHost }}
-    {{- end }}
   tls:
     - secretName: {{ .Values.ingress.httpHost }}-tls
       hosts:

--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.176 # Chart version
+version: 0.0.177 # Chart version
 appVersion: 2.12.47 # Version of deployed app
 keywords:
   - buildbuddy


### PR DESCRIPTION
Let's not gate the host configuration behind a test-only config flag.
