### PR TITLE
executor: pass pod's UID to executor

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.182 # Chart version
+version: 0.0.183 # Chart version
 appVersion: 2.15.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -71,6 +71,20 @@ spec:
             {{- .Values.resources | toYaml | nindent 12 }}
           {{- end }}
           env:
+            - name: MY_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: MY_NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: HOME
+              value: /buildbuddy
             {{- if not .Values.config.executor.memory_bytes }}
             - name: SYS_MEMORY_BYTES
               valueFrom:
@@ -83,14 +97,6 @@ spec:
                 resourceFieldRef:
                   resource: limits.cpu
             {{- end }}
-            - name: MY_HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: MY_NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             {{- if .Values.poolName }}
             - name: MY_POOL
               value: {{ .Values.poolName }}


### PR DESCRIPTION
This is a follow up from
https://github.com/buildbuddy-io/buildbuddy/pull/4326.

Make use of the new variable.
Set `$HOME=/buildbuddy` to retain the `.config/buildbuddy/host_id` between accidental container restarts.
