### PR TITLE
executor: ensure that securityContext is set when podman is used

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.184 # Chart version
+version: 0.0.185 # Chart version
 appVersion: 2.16.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -148,6 +148,9 @@ spec:
             privileged: true
             {{- end }}
             {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
+          {{- else if .Values.config.executor.enable_podman }}
+          securityContext:
+            privileged: true
           {{- end }}
       volumes:
         - name: executor-data


### PR DESCRIPTION
When podman is enabled but there isn't a security context available in
values.yaml config, the 'privileged' setting, required for running
nested podman container within a pod, is not properly rendered.

Provide an additional `else if` clause for that scenario.

Closes https://github.com/buildbuddy-io/buildbuddy-internal/issues/2550
