### PR TITLE
Avoid setting custom $HOME

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -124,8 +124,8 @@ spec:
                 - name: server-type
                   value: buildbuddy-executor
           volumeMounts:
-            - mountPath: /root/buildbuddy/
-              name executor-root-dir
+            - mountPath: /root/.config/buildbuddy/
+              name user-config-buildbuddy
             - mountPath: /buildbuddy/
               name: executor-data
             - mountPath: /config.yaml
@@ -153,7 +153,7 @@ spec:
             privileged: true
           {{- end }}
       volumes:
-        - name: executor-root-dir
+        - name: user-config-buildbuddy
           emptyDir: {}
         - name: executor-data
           emptyDir: {}

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -83,8 +83,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
-            - name: HOME
-              value: /buildbuddy
             {{- if not .Values.config.executor.memory_bytes }}
             - name: SYS_MEMORY_BYTES
               valueFrom:
@@ -126,6 +124,8 @@ spec:
                 - name: server-type
                   value: buildbuddy-executor
           volumeMounts:
+            - mountPath: /root/buildbuddy/
+              name executor-root-dir
             - mountPath: /buildbuddy/
               name: executor-data
             - mountPath: /config.yaml
@@ -153,6 +153,8 @@ spec:
             privileged: true
           {{- end }}
       volumes:
+        - name: executor-root-dir
+          emptyDir: {}
         - name: executor-data
           emptyDir: {}
         - name: config


### PR DESCRIPTION
In #63, we set a custom $HOME env variable pointing to /buildbuddy,
which is an emptyDir volumeMount, so that configs stored in
`os.UserConfigDir() + "/buildbuddy"` is persisted. (1) (2)

However, as #65 pointed out, overriding $HOME will cause container tools
such as docker, podman, to look up configs and credential helpers in the
wrong directory.

Unset the custom $HOME. Create a custom emptyDir volume mount for the
buildbuddy user config dir.

Closes #65.

(1): https://github.com/buildbuddy-io/buildbuddy/blob/c41d920e53326e75b7bb5c44d2b704ecac0e0ff9/server/util/uuid/uuid.go#L74-L79

(2): https://pkg.go.dev/os#UserConfigDir
