### PR TITLE
ingress: stop using ingress.class annotation for ALB

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.222 # Chart version
+version: 0.0.223 # Chart version
 appVersion: 2.24.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/alb.yaml
+++ b/charts/buildbuddy-enterprise/templates/alb.yaml
@@ -18,8 +18,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "alb"
-
     alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
     alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
@@ -58,8 +56,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "alb"
-
     alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
     alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
@@ -96,8 +92,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
-    kubernetes.io/ingress.class: "alb"
-
     alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
     alb.ingress.kubernetes.io/backend-protocol-version: "HTTP1"
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}

--- a/charts/buildbuddy/Chart.yaml
+++ b/charts/buildbuddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Open Source
 name: buildbuddy
-version: 0.0.184 # Chart version
+version: 0.0.185 # Chart version
 appVersion: 2.24.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy/templates/ingress.yaml
+++ b/charts/buildbuddy/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if and (lt .Capabilities.KubeVersion.Minor "18") (nq .Values.ingress.class "alb") }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       grpc_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504 non_idempotent;
@@ -55,7 +57,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if and (lt .Capabilities.KubeVersion.Minor "18") (nq .Values.ingress.class "alb") }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}


### PR DESCRIPTION
The annotation `kubernetes.io/ingress.class` has been deprecated since
Kubernetes 1.18 in favor of spec.ingressClassName.

However, some controllers, such as GKE Ingress controller, are still
mandate usage of the deprecated annotation. (1)

Remove the annotation specifically for ALB use case for now.

Future improvements could potentially make this annotation GKE specific
depending on users' reports.

(1): https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#deprecated_annotation

Closes #67
