### PR TITLE
executor: remove autoscaling based on CPU/Memory

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.201 # Chart version
+version: 0.0.202 # Chart version
 appVersion: 2.28.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/autoscaler.yaml
+++ b/charts/buildbuddy-executor/templates/autoscaler.yaml
@@ -20,18 +20,6 @@ spec:
     {{- .Values.autoscaler.behavior | toYaml | nindent 4 }}
 {{ end }}
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.autoscaler.averageCPU }}
-  - type: Resource
-    resource:
-      name: memory
-      target:
-        type: Utilization
-        averageUtilization: {{ .Values.autoscaler.averageMemory }}
   - type: Pods
     pods:
       metric:

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -68,8 +68,6 @@ autoscaler:
   enabled: false
 #   minReplicas: 3
 #   maxReplicas: 100
-#   averageCPU: 90
-#   averageMemory: 50
 #   averageQueueLength: 5
 #   ## Optional scaling behavior
 #   ## https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-policies


### PR DESCRIPTION
Some executor deployments will consume and retain memory on the host,
which make CPU/Memory based scaling inaccurate.

RBE queue length is a much better metrics to determine when
you should scale up/down your executor deployment.
