### PR TITLE
executor: add support for minReadySeconds

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.212 # Chart version
+version: 0.0.213 # Chart version
 appVersion: 2.35.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.minReadySeconds}}
+      minReadySeconds: {{ .Values.minReadySeconds }}
+      {{- end }}
       containers:
         {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -94,6 +94,15 @@ config:
     local_cache_size_bytes: 5000000000  # 5GB
     docker_socket: /var/run/docker.sock
 
+# Configuration for Deployment Rollout Staggering
+# The 'minReadySeconds' config delays the rollout process during a RollingUpdate.  This delay allows the
+# new Executor time for initialization, which includes picking up new actions, downloading necessary
+# container images and inputs.  As a result, it prevents the immediate replacement of the old Executor.
+# By setting this config, the impact of 'helm upgrade' on ongoing operations is minimized, ensuring a
+# smoother transition between different chart releases.
+#
+# minReadySeconds: 300
+
 ## Additional env vars
 extraEnvVars: []
 


### PR DESCRIPTION
Provide a configuration that would let user slow down the replacement of
pods during a RollingUpdate. This should give newer pods time to warm up
and reach the desired action execution speed, before shutting down the
older pods.
