### PR TITLE
executor: move minReadySeconds to deployment spec      

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.213 # Chart version
+version: 0.0.214 # Chart version
 appVersion: 2.35.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.minReadySeconds}}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       annotations:
@@ -55,9 +58,6 @@ spec:
       {{- if .Values.tolerations}}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
-      {{- end }}
-      {{- if .Values.minReadySeconds}}
-      minReadySeconds: {{ .Values.minReadySeconds }}
       {{- end }}
       containers:
         {{- if .Values.extraContainers }}


### PR DESCRIPTION
This was wrongly set in Pod Template spect instead of Deployment spec.

Thanks to @amartani for the report