### PR TITLE
executor: Do not set replicas when autoscaling is enabled

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.215 # Chart version
+version: 0.0.216 # Chart version
 appVersion: 2.36.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -11,7 +11,9 @@ metadata:
     {{- .Values.extraPodLabels | toYaml | nindent 4 }}
     {{- end }}
 spec:
+  {{- if not .Values.autoscaler.enabled }}
   replicas: {{ .Values.replicas | default 1 }}
+  {{- end }}
   strategy:
     type: RollingUpdate
   selector:


### PR DESCRIPTION
Explicitly setting `replicas` will cause Kubernetes to always set the number of replicas to the specified value, even when autoscaling is in use. The impact is that, during any update, the number of replicas will go back to the configured value and will have to rely on autoscaling to bring it back to the original value. Excluding `replicas` when autoscaling is enabled allows it to maintain the value from autoscaling during upgrades.

See https://github.com/kubernetes/kubernetes/issues/25238