### PR TITLE
buildbuddy-redis: allow specifying tolerations and nodeSelector

### DIFF
--- a/charts/buildbuddy-redis/Chart.yaml
+++ b/charts/buildbuddy-redis/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Redis LRU
 name: buildbuddy-redis
-version: 0.0.10 # Chart version
+version: 0.0.11 # Chart version
 appVersion: 5.0.4 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-redis/templates/deployment.yaml
+++ b/charts/buildbuddy-redis/templates/deployment.yaml
@@ -33,6 +33,14 @@ spec:
         {{- .Values.extraPodLabels | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.nodeSelector}}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations}}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/buildbuddy-redis/values.yaml
+++ b/charts/buildbuddy-redis/values.yaml
@@ -14,12 +14,12 @@ image:
 ## Using multiple replicas with a sqlite3 database or disk storage is not supported.
 replicas: 1
 
-## The nodeSelector used for placing executors and apps in separate node pools/groups (useful when autoscaling executors)
+## The nodeSelector used for placing pods in separate node pools/groups
 # nodeSelector:
 #   # GCP
-#   cloud.google.com/gke-nodepool: my-executor-pool
+#   cloud.google.com/gke-nodepool: my-redis-pool
 #   # AWS
-#   eks.amazonaws.com/nodegroup: my-executor-pool
+#   eks.amazonaws.com/nodegroup: my-redis-pool
 
 ## The taints to schedule pods on (useful for mixed architecture clusters)
 # tolerations:

--- a/charts/buildbuddy-redis/values.yaml
+++ b/charts/buildbuddy-redis/values.yaml
@@ -14,6 +14,20 @@ image:
 ## Using multiple replicas with a sqlite3 database or disk storage is not supported.
 replicas: 1
 
+## The nodeSelector used for placing executors and apps in separate node pools/groups (useful when autoscaling executors)
+# nodeSelector:
+#   # GCP
+#   cloud.google.com/gke-nodepool: my-executor-pool
+#   # AWS
+#   eks.amazonaws.com/nodegroup: my-executor-pool
+
+## The taints to schedule pods on (useful for mixed architecture clusters)
+# tolerations:
+#   - effect: NoSchedule
+#     key: hardware_requirements
+#     operator: Equal
+#     value: x86_64
+
 ## Maximum memory redis will use, should be less than the kubernetes resource limits below.
 maxMemory: "5gb"
 


### PR DESCRIPTION
Follow-up for PR #71 - change did not include `buildbuddy-redis` Chart. Also while at it, allowing specifying `nodeSelector`.