### PR TITLE
enterprise: replace deprecated ingress annotations

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.250 # Chart version
+version: 0.0.251 # Chart version
 appVersion: 2.44.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/grafana.yaml
+++ b/charts/buildbuddy-enterprise/templates/grafana.yaml
@@ -9,9 +9,14 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if lt .Capabilities.KubeVersion.Minor "18" }}
     kubernetes.io/ingress.class: nginx
+    {{- end }}
     kubernetes.io/ingress.provider: nginx
 spec:
+  {{- if ge .Capabilities.KubeVersion.Minor "18" }}
+  ingressClassName: nginx
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.httpHost }}
       http:

--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -15,7 +15,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if lt .Capabilities.KubeVersion.Minor "18" }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     {{- if .Values.certmanager.enabled }}
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -39,6 +41,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
 spec:
+  {{- if ge .Capabilities.KubeVersion.Minor "18" }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.grpcHost }}
     http:
@@ -67,7 +72,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if lt .Capabilities.KubeVersion.Minor "18" }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
     nginx.ingress.kubernetes.io/server-alias: "~.*@{{ .Values.ingress.grpcHost | replace "." "\\\\." }}"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -86,6 +93,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
 spec:
+  {{- if ge .Capabilities.KubeVersion.Minor "18" }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
   rules:
     - http:
         paths:
@@ -112,7 +122,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "buildbuddy.chart" . }}
   annotations:
+    {{- if lt .Capabilities.KubeVersion.Minor "18" }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+    {{- end }}
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}
@@ -123,6 +135,9 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
 spec:
+  {{- if ge .Capabilities.KubeVersion.Minor "18" }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.httpHost }}
     http:


### PR DESCRIPTION
This annotation was marked as deprecated in 2020
https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation.

Replace it with `spec.ingressClassName`
