### PR TITLE
sluongng/dont autoscale distributed app

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.254 # Chart version
+version: 0.0.255 # Chart version
 appVersion: 2.47.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/autoscaler.yaml
+++ b/charts/buildbuddy-enterprise/templates/autoscaler.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.autoscaler.enabled }}
+{{ if and .Values.autoscaler.enabled (not .Values.distributed.enabled) }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -225,6 +225,9 @@ redis:
   enabled: false
 
 # Autoscaler for buildbuddy-app instances
+#
+# This will NOT work if distributed.enabled is true.
+# See https://github.com/buildbuddy-io/buildbuddy-helm/issues/23 for more info.
 autoscaler:
   enabled: false
 #   minReplicas: 3


### PR DESCRIPTION
In distributed mode, "app" will be deployed as a StatefulSet in a
consistent hash ring, which is not friendly to autoscaler.

For the time being, we recommend manually scaling "app" under distributed
mode instead of using autoscaler.

Note that BuildBuddy Executor is still compatible with autoscaler, this
change is only applicable to "app" deployment.

Closes https://github.com/buildbuddy-io/buildbuddy-helm/issues/23.