### PR TITLE
executor: add additional volume mount for run root

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.230 # Chart version
+version: 0.0.231 # Chart version
 appVersion: 2.48.2 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -147,6 +147,8 @@ spec:
             {{- if .Values.config.executor.enable_podman }}
             - name: containers-lib
               mountPath: /var/lib/containers
+            - name: containers-run
+              mountPath: /run/containers
             {{- end }}
             {{- if .Values.extraVolumeMounts -}}
             {{ .Values.extraVolumeMounts | toYaml | nindent 12 }}
@@ -176,6 +178,8 @@ spec:
         {{- end }}
         {{- if .Values.config.executor.enable_podman }}
         - name: containers-lib
+          emptyDir: {}
+        - name: containers-run
           emptyDir: {}
         {{- end }}
         {{- if .Values.extraVolumes -}}


### PR DESCRIPTION
Podman has 2 default storage path:
- Graph Root: /var/lib/containers/storage
- Run Root: /run/containers/storage

As of recent version of Podman, the default SQLite database that is used
to keep track of container states are written to Graph Root.
However, when the transient store option is enabled, podman will write
the database to Run Root path instead. (1)
Provide a dedicated mountPath for Run Root using emptyDir.

Users are advised to make sure that the underlying filesystem / disk
that is serving this Run Root to be performance enough so that the
SQLite database is not throttle podman container operations.
Avoiding Network Storage solution should suffice.

(1): https://github.com/containers/podman/blob/6487940534c1065d6c7753e3b6dfbe253666537d/libpod/sqlite_state.go#L61-L66
