### PR TITLE
enterprise: default to Pebble cache

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.300 # Chart version
+version: 0.0.301 # Chart version
 appVersion: 2.87.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/migration-cache.values.yaml
+++ b/charts/buildbuddy-enterprise/migration-cache.values.yaml
@@ -1,0 +1,15 @@
+# Example values.yaml to setup Migration Cache.
+#
+# We do NOT recommend using this for most self-hosted installations of BuildBuddy.
+# Please contact our support for more information.
+cache:
+  max_size_bytes: 10000000000 # 10 GB
+  migration:
+    double_read_percentage: 1
+    src:
+      disk:
+        root_directory: "/data/buildbuddy/cache/"
+    dest:
+      pebble:
+        root_directory: "/data/buildbuddy/pebble-cache/"
+

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -346,9 +346,9 @@ config:
     #   project_id: "my-gc-project"
     #   credentials_file: "my-volume/my-google-credentials.json"
   cache:
-    disk:
-      root_directory: "/data/buildbuddy/cache/" # Enabled disk.data volume above to use
     max_size_bytes: 10000000000 # 10 GB
+    pebble:
+      root_directory: /data/buildbuddy/pebble-cache/
   ssl:
     enable_ssl: false
     client_ca_cert_file: "" # DO NOT EDIT: Automatically configured using certmanager


### PR DESCRIPTION
Switch from disk cache to pebble cache as the default cache storage
backend.

Also provide an example of how Migration Cache could be setup for future
references.
