### PR TITLE
mysql: change init container to busybox and nc

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.273 # Chart version
+version: 0.0.274 # Chart version
 appVersion: 2.65.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
       - name: "init-mysql"
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-        command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+        command: ["sh", "-c", "until nc -z {{ .Release.Name }}-mysql 3306; do echo waiting for {{ .Release.Name }}-mysql service; sleep 5; done;"]
       {{- end }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -395,7 +395,7 @@ extraVolumeMounts: []
 
 ## Container image that is used to ping mysql until it's up.
 initContainerImage:
-  repository: appropriate/curl
+  repository: busybox
   tag: latest
   imagePullPolicy: IfNotPresent
 

--- a/charts/buildbuddy/Chart.yaml
+++ b/charts/buildbuddy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Open Source
 name: buildbuddy
-version: 0.0.233 # Chart version
+version: 0.0.234 # Chart version
 appVersion: 2.65.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy/templates/deployment.yaml
+++ b/charts/buildbuddy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - name: "init-mysql"
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-        command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
+        command: ["sh", "-c", "until nc -z http://{{ .Release.Name }}-mysql 3306; do echo waiting for {{ .Release.Name }}-mysql service; sleep 5; done;"]
       {{- end }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}

--- a/charts/buildbuddy/values.yaml
+++ b/charts/buildbuddy/values.yaml
@@ -196,7 +196,7 @@ extraVolumeMounts: []
 
 ## Container image that is used to ping mysql until it's up.
 initContainerImage:
-  repository: appropriate/curl
+  repository: busybox
   tag: latest
   imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
In the future, we want to add support for other databases to this helm
chart, such as ClickHouse for OLAP workloads. Each of these new
databases will require their own init containers to check if the main
port is available.

Instead of using multiple container images for multiple tools, let's
simplify the setup using netcat `nc` inside `busybox` image.
