### PR TITLE
executor: allow custom executor-data location

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -167,7 +167,12 @@ spec:
         - name: user-config-buildbuddy
           emptyDir: {}
         - name: executor-data
+          {{- if .Values.executorDataVolumeHostPath }}
+          hostPath:
+            path: {{ .Values.executorDataVolumeHostPath }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: config
           secret:
             secretName: {{ include "buildbuddy.fullname" . }}-config

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -114,6 +114,10 @@ extraInitContainers: []
 ## Additional containers
 extraContainers: []
 
+## Path on the node to mount 'executor-data' volume.
+## If not set, 'executor-data' will use emptyDir.
+# executorDataVolumeHostPath: ""
+
 # Add additional volumes and mounts
 extraVolumes: []
 extraVolumeMounts: []


### PR DESCRIPTION
On some platforms such as AWS's EKS, user might want to move their
entire executor-data volume onto a RAID-0 over NVMe instance store disks
as described in (1).

Currently, this could be achieved with a combination of `extraVolumes`,
`extraVolumeMounts`, and then set `config.executor.root_directory`
and `config.executor.local_cache_directory` to the desired path(s).
However, such a setup could be unweildy and harder to maintain.

Provide a config that would let users change `executor-data`,
which corresponds to the `/buildbuddy` dir inside our container, from
`emptyDir` to `hostPath`.

(1): https://aws.amazon.com/blogs/containers/eks-persistent-volumes-for-instance-store/
