### PR TITLE
enterprise: enable flags when clickhouse is available

### DIFF
--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -87,9 +87,6 @@ spec:
               .Values.clickhouse.enabled 
               .Values.config.app.olap_database.data_source
           }}
-          {{- if not (hasKey .Values.config.app "enable_write_to_olap_db") }}
-            - --app.enable_write_to_olap_db=true
-          {{- end }}
           {{- if not (hasKey .Values.config.app "enable_target_tracking") }}
             - --app.enable_target_tracking=true
           {{- end }}

--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -82,6 +82,25 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
           args:
+          {{- /* ClickHouse specific configs - START */ -}}
+          {{- if or
+              .Values.clickhouse.enabled 
+              .Values.config.app.olap_database.data_source
+          }}
+          {{- if not (hasKey .Values.config.app "enable_write_to_olap_db") }}
+            - --app.enable_write_to_olap_db=true
+          {{- end }}
+          {{- if not (hasKey .Values.config.app "enable_target_tracking") }}
+            - --app.enable_target_tracking=true
+          {{- end }}
+          {{- if not (hasKey .Values.config.app "enable_write_test_target_statuses_to_olap_db") }}
+            - --app.enable_write_test_target_statuses_to_olap_db=true
+          {{- end }}
+          {{- if not (hasKey .Values.config.app "trends_range_selection") }}
+            - --app.trends_range_selection=true
+          {{- end }}
+          {{- end }}
+          {{- /* ClickHouse specific configs - END */ -}}
           {{- if .Values.args }}
             {{- .Values.args | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
When users want to try out clickhouse, let's enable some flags to
improve the overall user experience.

We only set these flags through the container's args if they were
not explicitly set in `config.yaml`. If they are explicitly set, then
then will be part of the config.yaml that our image will pickup.

We might also want to add `target_flakes_ui_enabled` in the near future
when it's ready.
