### PR TITLE
enterprise: remove at-grpc ingress

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.280 # Chart version
+version: 0.0.281 # Chart version
 appVersion: 2.69.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/alb.yaml
+++ b/charts/buildbuddy-enterprise/templates/alb.yaml
@@ -49,42 +49,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "buildbuddy.fullname" . }}-at-grpc
-  labels:
-    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "buildbuddy.chart" . }}
-  annotations:
-    alb.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    alb.ingress.kubernetes.io/backend-protocol-version: "GRPC"
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.alb.certificateArn }}
-    alb.ingress.kubernetes.io/ssl-redirect: "443"
-
-    {{- with .Values.ingress.annotations }}
-    {{- . | toYaml | nindent 4 }}
-    {{- end }}
-spec:
-  {{ if ge .Capabilities.KubeVersion.Minor "18" }}
-  ingressClassName: "alb"
-  {{ end }}
-  rules:
-    - http:
-        paths:
-          - pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ include "buildbuddy.name" . }}
-                port:
-                  name: grpc
-  tls:
-    - secretName: {{ .Values.ingress.grpcHost }}-tls
-      hosts:
-        - {{ .Values.ingress.grpcHost }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: {{ include "buildbuddy.fullname" . }}-http
   labels:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}

--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -65,56 +65,6 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "buildbuddy.fullname" . }}-at-grpc
-  labels:
-    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "buildbuddy.chart" . }}
-  annotations:
-    {{- if lt .Capabilities.KubeVersion.Minor "18" }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
-    {{- end }}
-    nginx.ingress.kubernetes.io/backend-protocol: "grpc"
-    nginx.ingress.kubernetes.io/server-alias: "~.*@{{ .Values.ingress.grpcHost | replace "." "\\\\." }}"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      grpc_set_header x-ssl-cert $ssl_client_escaped_cert;
-      grpc_set_header x-buildbuddy-api-key $api_key;
-      grpc_set_header x-buildbuddy-auth-type $host_auth_type;
-      grpc_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504 non_idempotent;
-      grpc_next_upstream_tries 3;
-    {{- if .Values.ingress.sslEnabled }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}
-    {{- else }}
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    {{- end }}
-    {{- with .Values.ingress.annotations }}
-    {{- . | toYaml | nindent 4 }}
-    {{- end }}
-spec:
-  {{- if ge .Capabilities.KubeVersion.Minor "18" }}
-  ingressClassName: {{ .Values.ingress.class }}
-  {{- end }}
-  rules:
-    - http:
-        paths:
-          - pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ include "buildbuddy.name" . }}
-                port:
-                  name: grpc
-  {{ if .Values.ingress.sslEnabled }}
-  tls:
-    - secretName: {{ .Values.ingress.grpcHost }}-tls
-      hosts:
-        - {{ .Values.ingress.grpcHost }}
-  {{ end }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
   name: {{ include "buildbuddy.fullname" . }}-http
   labels:
     app.kubernetes.io/name: {{ include "buildbuddy.name" . }}


### PR DESCRIPTION
We no longer need to support `user@my-buildbuddy.io` host name now that
Bazel comes with `--remote_header=` flag.
