### PR TITLE
executor: add host path config for podman volumes

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.257 # Chart version
+version: 0.0.258 # Chart version
 appVersion: 2.72.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -183,9 +183,19 @@ spec:
         {{- end }}
         {{- if .Values.config.executor.enable_podman }}
         - name: containers-lib
+          {{- if .Values.podmanGraphRootVolumeHostPath }}
+          hostPath:
+            path: {{ .Values.podmanGraphRootVolumeHostPath}}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: containers-run
+          {{- if .Values.podmanRunRootVolumeHostPath }}
+          hostPath:
+            path: {{ .Values.podmanRunRootVolumeHostPath}}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         {{- end }}
         {{- if .Values.extraVolumes -}}
         {{ .Values.extraVolumes | toYaml | nindent 8 }}

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -118,6 +118,18 @@ extraContainers: []
 ## If not set, 'executor-data' will use emptyDir.
 # executorDataVolumeHostPath: ""
 
+## Path on the node to mount Podman 'containers-lib' volume,
+## which is mounted to /var/lib/containers inside the Executor pod.
+##
+## If not set, 'containers-lib' will use emptyDir.
+# podmanGraphRootVolumeHostPath: ""
+
+## Path on the node to mount Podman 'containers-run' volume,
+## which is mounted to /run/containers inside the Executor pod.
+##
+## If not set, 'containers-run' will use emptyDir.
+# podmanRunRootVolumeHostPath: ""
+
 # Add additional volumes and mounts
 extraVolumes: []
 extraVolumeMounts: []


### PR DESCRIPTION
In some Kubernetes setup, emptyDir volume could point to slower
network storage on the Node.

Provide configs to set podman volumes to use host paths instead of
emptyDir. Users could use these configs to setup these volumes on
a faster storage medium on the Nodes.
