### PR TITLE
enterprise: add support for minReadySeconds

### DIFF
--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.minReadySeconds}}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -431,3 +431,12 @@ initContainerImage:
 ## Affinity (optional) could be used to configured 'app' pods to be deployed in separate nodes,
 ## or nodes with a certain type of storage volume available.
 affinity: {}
+
+# # Configuration for Deployment Rollout Staggering
+# The 'minReadySeconds' config delays the rollout process during a Deployment's RollingUpdate or
+# StatefulSet.  This delay allows the new App pods time for initialization and prevents the immediate
+# replacement of the old App pods.  This is useful to maintain high cache availability in deployments
+# with low replication factor (<=2).   By setting this config, the impact of 'helm upgrade' on ongoing
+# operations is minimized, ensuring a smoother transition between different chart releases.
+#
+# minReadySeconds: 300


### PR DESCRIPTION
For deployments with smaller replication factor, a fast rollout can
cause 2 replicas in a StatefulSet to be unavailable at the same time.
This could cause some CAS entries to be temporarily unavailable from the
deployment, resulting in AC entries using these CAS entries to also be
unavailable.

Our recommendation for these cases is to use higher replication factor
(>=3).  Combining a high replication factor with a PodDisruptionBudget
where `maxUnavailable: 1` should be sufficient in preventing any cache
unavailability.

For users with a fixed storage budget and cannot scale up the
replication factor. Using `spec.minReadySeconds` to stagger the
Deployment/StatefulSet rollout could be a good alternative.  This time
duration should allows the new pod to properly receive all the [hinted
handoff](1) from the old pod before K8s proceed to replace the old pod.

(1): https://cassandra.apache.org/doc/stable/cassandra/operating/hints.html#hinted-handoff
