### PR TITLE
buildbuddy: fix wrong init-mysql command

### DIFF
--- a/charts/buildbuddy/templates/deployment.yaml
+++ b/charts/buildbuddy/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       - name: "init-mysql"
         image: "{{ .Values.initContainerImage.repository }}:{{ .Values.initContainerImage.tag }}"
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
-        command: ["sh", "-c", "until nc -z http://{{ .Release.Name }}-mysql 3306; do echo waiting for {{ .Release.Name }}-mysql service; sleep 5; done;"]
+        command: ["sh", "-c", "until nc -z {{ .Release.Name }}-mysql 3306; do echo waiting for {{ .Release.Name }}-mysql service; sleep 5; done;"]
       {{- end }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}


### PR DESCRIPTION
This was accidentally added in
https://github.com/buildbuddy-io/buildbuddy-helm/pull/98.

Reported-by: @blackliner 
