### PR TITLE
add PodDisruptionBudget to executor chart

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.272 # Chart version
+version: 0.0.273 # Chart version
 appVersion: 2.86.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/poddisruptionbudget.yaml
+++ b/charts/buildbuddy-executor/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "buildbuddy.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "buildbuddy.chart" . }}
+spec:
+  {{ toYaml .Values.podDisruptionBudget.spec }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
+{{ end }}

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -82,6 +82,13 @@ autoscaler:
 #   #       value: 10
 #   #       periodSeconds: 60
 
+podDisruptionBudget:
+  enabled: false
+  spec:
+    ## Only one of minAvailable or maxUnavailable may be specified
+    # maxUnavailable: 40%
+    minAvailable: 60%
+
 # NOTE: These acts as the default values for the config.yaml file read by the
 # buildbuddy server itself. You can override the config object just like any
 # Helm template value. Since it is an object, the object you provide will merge


### PR DESCRIPTION
adds an optional PodDisruptionBudget object to the executor chart. this is useful for enforcing a baseline level of capacity during node replacement operations.

arguably a minor version bump, but I opted for a patch given that it's still 0.0.x. happy to make it 0.1.0 if desired.