### PR TITLE
executor: support using custom metrics with autoscaler

### DIFF
--- a/charts/buildbuddy-executor/templates/autoscaler.yaml
+++ b/charts/buildbuddy-executor/templates/autoscaler.yaml
@@ -20,11 +20,15 @@ spec:
     {{- .Values.autoscaler.behavior | toYaml | nindent 4 }}
 {{ end }}
   metrics:
-  - type: Pods
-    pods:
-      metric:
-        name: buildbuddy_remote_execution_queue_length
-      target:
-        type: AverageValue
-        averageValue: {{ .Values.autoscaler.averageQueueLength }}
+  {{- if .Values.autoscaler.metrics }}
+    {{- .Values.autoscaler.metrics | toYaml | nindent 4 }}
+  {{- else }}
+    - type: Pods
+      pods:
+        metric:
+          name: buildbuddy_remote_execution_queue_length
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.autoscaler.averageQueueLength }}
+  {{- end }}
 {{ end }}

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -71,16 +71,25 @@ autoscaler:
 #   averageQueueLength: 5
 #   ## Optional scaling behavior
 #   ## https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-policies
-#   # behavior:
-#   #   scaleDown:
-#   #     stabilizationWindowSeconds: 600
-#   #     policies:
-#   #     - type: Pods
-#   #       value: 2
-#   #       periodSeconds: 10
-#   #     - type: Percent
-#   #       value: 10
-#   #       periodSeconds: 60
+#   behavior:
+#     scaleDown:
+#       stabilizationWindowSeconds: 600
+#       policies:
+#       - type: Pods
+#         value: 2
+#         periodSeconds: 10
+#       - type: Percent
+#         value: 10
+#         periodSeconds: 60
+#   ## Optional custom metrics
+#   metrics:
+#   - type: Pods
+#     pods:
+#       metric:
+#         name: my_custom_metric
+#       target:
+#         type: AverageValue
+#         averageValue: 5
 
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
Provide the ability to use a custom set of metrics for the autoscaler.
This enable folks who rely on a custom metric adapter, such as (1), to
use a different metric name than the default name straight from out
application.

(1): https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics
