### PR TITLE
Executors: Add runtimeClassName

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     {{- end }}
 spec:
   {{- if .Values.runtimeClassName }}
-  {{- .Values.runtimeClassName | toYaml | nindent 4 }}
+  runtimeClassName: {{ .Values.runtimeClassName }}
   {{- end }}
   {{- if not .Values.autoscaler.enabled }}
   replicas: {{ .Values.replicas | default 1 }}


### PR DESCRIPTION
Needed for running the executor pods on GKE Sandbox - link to GKE docs:
https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods#sandboxed-application