### PR TITLE
feat: add container security context as it has non overlapping features with pod security context

### DIFF
--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+          {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           args:
           {{- if .Values.args }}
             {{- .Values.args | toYaml | nindent 12 }}

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+          {{- if .Values.containerSecurityContext }}
+          securityContext:
+          {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.customExecutorCommand }}
           command:
           {{- .Values.customExecutorCommand | toYaml | nindent 10}}


### PR DESCRIPTION
I wanted to configure `readOnlyRootFilesystem` in the securityContext. But then I noticed that pod and container security contexts have slight differences: https://medium.com/pareture/k8s-podsecuritycontext-vs-containersecuritycontext-4ca682670f7b

This PR adds containerSecurityContext so that we can set container specific context settings