### PR TITLE
executor: Add an optional serviceAccount.name to values.yaml

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.296 # Chart version
+version: 0.0.297 # Chart version
 appVersion: 2.112.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -61,6 +61,9 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         {{- if .Values.extraContainers }}
         {{- toYaml .Values.extraContainers | nindent 8 }}

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.name }}
+      {{- if and .Values.serviceAccount .Values.serviceAccount.name }}
       serviceAccountName: {{ .Values.serviceAccount.name }}
       {{- end }}
       containers:

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -153,3 +153,11 @@ extraVolumeMounts: []
 ## Affinity (optional) could be used to configured 'executor' pods to be deployed
 ## on nodes with a certain type of storage volume or hardware available.
 affinity: {}
+
+## Optionally, set a different service account for the executor pods. Setting
+## this is not required for normal 'executor' operation; the `default` SA is
+## sufficient. It is available in case you need to grant the pods additional
+## permissions via SA. Note that the chart does not create the SA, so you should
+## create it on your own.
+serviceAccount:
+  name: default

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -159,5 +159,5 @@ affinity: {}
 ## sufficient. It is available in case you need to grant the pods additional
 ## permissions via SA. Note that the chart does not create the SA, so you should
 ## create it on your own.
-serviceAccount:
-  name: default
+# serviceAccount:
+#   name: default


### PR DESCRIPTION
## context

we'd like our executors running in AWS EKS to pull docker images from our private ECR registry. the pods need AWS IAM credentials to auth to the docker registry, which we can conveniently get IAM creds in EKS via [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), but we need to be able to set the service account name that the pod uses.

## changes

- executor values.yaml: add `serviceAccount.name` value, default to current behaviour (use `default` SA)
- deployment.yaml: use the service account, if specified

## testing

still renders when value is not set, also does not set serviceAccountName
```
bash-5.2$ helm template . | grep serviceAccount
```

when setting the `.serviceAccount.name`, it shows up in the spec as expected

```
bash-5.2$ helm template . --set serviceAccount.name=test | grep -C3 serviceAccount
        app.kubernetes.io/managed-by: Helm
        helm.sh/chart: buildbuddy-executor-0.0.297
    spec:
      serviceAccountName: test
      containers:
        - name: buildbuddy-executor
          image: "gcr.io/flame-public/buildbuddy-executor-enterprise:enterprise-v2.112.0"
```

made sure the resulting YAML is still valid, with the correct service account

```
bash-5.2$ helm template . --set serviceAccount.name=test > fun.yaml
bash-5.2$ kc apply -f fun.yaml
deployment.apps/release-name-buildbuddy-executor created
bash-5.2$ kc get deploy/release-name-buildbuddy-executor -ojson | jq '.spec.template.spec.serviceAccountName'
"test"
bash-5.2$ 
```

and saw that the replicaSet refused to make pods cuz i didn't have an SA `test`, as expected:

```
Events:
  Type     Reason        Age                   From                   Message
  ----     ------        ----                  ----                   -------
  Warning  FailedCreate  79s (x15 over 2m41s)  replicaset-controller  Error creating: pods "release-name-buildbuddy-executor-759cdbc745-" is forbidden: error looking up service account default/test: serviceaccount "test" not found
```