### PR TITLE
enterprise: adjust nginx ingress config

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.330 # Chart version
+version: 0.0.331 # Chart version
 appVersion: 2.119.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/ingress.yaml
+++ b/charts/buildbuddy-enterprise/templates/ingress.yaml
@@ -19,18 +19,16 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
     {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "grpc"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      grpc_set_header x-ssl-cert $ssl_client_escaped_cert;
+      grpc_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504 non_idempotent;
+      grpc_next_upstream_tries 3;
     {{- if .Values.certmanager.enabled }}
     nginx.ingress.kubernetes.io/server-snippet: |
       ssl_verify_client optional;
       ssl_verify_depth 1;
       ssl_client_certificate /client-ca/tls.crt;
     {{ end }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      grpc_set_header x-ssl-cert $ssl_client_escaped_cert;
-      grpc_set_header x-buildbuddy-api-key $api_key;
-      grpc_set_header x-buildbuddy-auth-type $cert_auth_type;
-      grpc_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504 non_idempotent;
-      grpc_next_upstream_tries 3;
     {{- if .Values.ingress.sslEnabled }}
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: {{ .Values.ingress.clusterIssuer | default "letsencrypt-prod"}}

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -148,7 +148,7 @@ ingress:
         client_body_buffer_size 4m;
         http2_idle_timeout 7200s;
         http2_max_concurrent_streams 10000;
-        http2_max_requests 100000;
+        keepalive_requests 100000;
       # This snippet handles pulling api keys from the cert or host and
       # shoving them into the $api_key variable / can be used in headers.
       http-snippet: |
@@ -156,12 +156,22 @@ ingress:
           default "";
           ~serialNumber=(?<api_key>[^,]*) "api_key_from_cert";
         }
+        if ($cert_auth_type != "") {
+          grpc_set_header x-buildbuddy-auth-type $cert_auth_type;
+        }
         map $host $host_auth_type {
           default "";
           ~^(?<api_key>[^@]*)@ "api_key_from_host";
         }
+        if ($host_auth_type != "") {
+          grpc_set_header x-buildbuddy-auth-type $host_auth_type;
+        }
         map $http_x_buildbuddy_api_key $api_key {
+          default "";
           "~." $http_x_buildbuddy_api_key;
+        }
+        if ($api_key != "") {
+          grpc_set_header x-buildbuddy-api-key $api_key;
         }
   # metrics:
   #   enabled: true


### PR DESCRIPTION
In the latest version of nginx ingress, the ordering of
`nginx.ingress.kubernetes.io/configuration-snippet` could be placed
before our http-snippet and thus, cause $api_key variable to be
undefined and fail the invalidation hook.

Move the grpc_set_header calls to directly below relevant http-snippet
and make them conditional.

Fixed missing host auth-type.

Replaced obsoleted `http2_max_requests` with `keepalive_requests`.
