### PR TITLE
executor: switch default isolation from podman to oci

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.305 # Chart version
+version: 0.0.306 # Chart version
 appVersion: 2.120.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -158,11 +158,11 @@ spec:
             {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
-            {{- if .Values.config.executor.enable_podman }}
+            {{- if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) }}
             privileged: true
             {{- end }}
             {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
-          {{- else if .Values.config.executor.enable_podman }}
+          {{- else if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) }}
           securityContext:
             privileged: true
           {{- end }}

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -108,9 +108,9 @@ config:
     root_directory: "/buildbuddy/remotebuilds/"
     local_cache_directory: "/buildbuddy/filecache/"
     local_cache_size_bytes: 5000000000  # 5GB
-    ## Use podman to spin up 'runner' child containers inside executor container.
-    enable_podman: true
-    default_isolation_type: podman
+    ## Use oci to spin up 'runner' child containers inside executor container.
+    enable_oci: true
+    default_isolation_type: oci
 
 # Configuration for Deployment Rollout Staggering
 # The 'minReadySeconds' config delays the rollout process during a RollingUpdate.  This delay allows the


### PR DESCRIPTION
"oci" isolation is our own container runtime based on crun.
It has less performance overhead compare to podman while being
compatible with existing container images.

We have been using it in our production environment for several months
now and should be matured enough for our customers to adopt it as well.

Similar to podman isolation, "oci" isolation runs action containers
inside the Executor container of the kubernetes pod. This means that the
outer Executor container requires priviledged permission to perform
setup needed for the action containers to run.
