### PR TITLE
enterprise/ingress: remove condition around grpc_set_header

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.334 # Chart version
+version: 0.0.335 # Chart version
 appVersion: 2.123.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -156,23 +156,17 @@ ingress:
           default "";
           ~serialNumber=(?<api_key>[^,]*) "api_key_from_cert";
         }
-        if ($cert_auth_type != "") {
-          grpc_set_header x-buildbuddy-auth-type $cert_auth_type;
-        }
+        grpc_set_header x-buildbuddy-auth-type $cert_auth_type;
         map $host $host_auth_type {
           default "";
           ~^(?<api_key>[^@]*)@ "api_key_from_host";
         }
-        if ($host_auth_type != "") {
-          grpc_set_header x-buildbuddy-auth-type $host_auth_type;
-        }
+        grpc_set_header x-buildbuddy-auth-type $host_auth_type;
         map $http_x_buildbuddy_api_key $api_key {
           default "";
           "~." $http_x_buildbuddy_api_key;
         }
-        if ($api_key != "") {
-          grpc_set_header x-buildbuddy-api-key $api_key;
-        }
+        grpc_set_header x-buildbuddy-api-key $api_key;
   # metrics:
   #   enabled: true
   #   service:


### PR DESCRIPTION
`if` directive is not allowed inside the main http block.
Revert to the previous logic where we set these headers
unconditionally.

