### PR TITLE
executor: allow extra configuration for probes

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.317 # Chart version
+version: 0.0.318 # Chart version
 appVersion: 2.137.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -128,6 +128,9 @@ spec:
               httpHeaders:
                 - name: server-type
                   value: buildbuddy-executor
+          {{- if .Values.extraLivenessProbeConfig }}
+            {{- .Values.extraLivenessProbeConfig | toYaml | nindent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /readyz
@@ -135,6 +138,9 @@ spec:
               httpHeaders:
                 - name: server-type
                   value: buildbuddy-executor
+          {{- if .Values.extraReadinessProbeConfig }}
+            {{- .Values.extraReadinessProbeConfig | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /root/.config/buildbuddy/
               name: user-config-buildbuddy

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -124,6 +124,16 @@ config:
 ## Additional env vars
 extraEnvVars: []
 
+## Probe configuration
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## Example:
+##   extraLivenessProbeConfigs:
+##     timeoutSeconds: 10
+##   extraReadinessProbeConfigs:
+##     timeoutSeconds: 10
+extraLivenessProbeConfig: {}
+extraReadinessProbeConfig: {}
+
 ## Additional init containers
 extraInitContainers: []
 


### PR DESCRIPTION
Users may want to customize their liveness/readiness probe to precisely
control how the pod is startup and health check.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
