### PR TITLE
buildbuddy-enterprise: add optional serviceAccount configuration

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.363 # Chart version
+version: 0.0.364 # Chart version
 appVersion: 2.160.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         {{- .Values.extraPodLabels | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if and .Values.serviceAccount .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       {{- if .Values.securityContext }}
       securityContext:
       {{- .Values.securityContext | toYaml | nindent 8 }}

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -444,3 +444,11 @@ affinity: {}
 # operations is minimized, ensuring a smoother transition between different chart releases.
 #
 # minReadySeconds: 300
+
+## Optionally, set a different service account for the 'app' pods. Setting
+## this is not required for normal 'app' operation; the `default` SA is
+## sufficient. It is available in case you need to grant the pods additional
+## permissions via SA. Note that the chart does not create the SA, so you should
+## create it on your own.
+# serviceAccount:
+#   name: default


### PR DESCRIPTION
Mirror the existing configuration from buildbuddy-executor helm chart.
Requested by one of our user via email.
