### PR TITLE
executor: add support for TopologySpreadConstraints

### DIFF
--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
   {{- if .Values.minReadySeconds}}
   minReadySeconds: {{ .Values.minReadySeconds }}
   {{- end }}
+  {{- if .Values.topologySpreadConstraints }}
+  topologySpreadConstraints:
+    {{ .Values.topologySpreadConstraints | toYaml | indent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -178,3 +178,16 @@ affinity: {}
 ## create it on your own.
 # serviceAccount:
 #   name: default
+
+## TopologySpreadConstraints for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+##
+## Example: The Executor pods should be evenly spread across zones
+# topologySpreadConstraints:
+#   - maxSkew: 1
+#     topologyKey: zone
+#     whenUnsatisfiable: DoNotSchedule
+#     labelSelector:
+#       matchLabels:
+#         foo: bar
+topologySpreadConstraints: []


### PR DESCRIPTION
Requested by one of our users via email.

This should give them better control when balancing the deployment between
on-demand and spot node pools while maintaining high availability.
