### PR TITLE
Enable privileged security context if firecracker is enabled

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.364 # Chart version
+version: 0.0.365 # Chart version
 appVersion: 2.197.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -168,11 +168,11 @@ spec:
             {{- end }}
           {{- if .Values.containerSecurityContext }}
           securityContext:
-            {{- if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) }}
+            {{- if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) (.Values.config.executor.enable_firecracker) }}
             privileged: true
             {{- end }}
             {{- .Values.containerSecurityContext | toYaml | nindent 12 }}
-          {{- else if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) }}
+          {{- else if or (.Values.config.executor.enable_podman) (.Values.config.executor.enable_oci) (.Values.config.executor.enable_firecracker) }}
           securityContext:
             privileged: true
           {{- end }}


### PR DESCRIPTION
Firecracker doesn't work unless in privileged mode.

Context: https://buildbuddy-corp.slack.com/archives/C0777L0C2UW/p1757023006056969?thread_ts=1756935242.851329&cid=C0777L0C2UW