### PR TITLE
Enable auto-sizing by default for on-prem RBE

### DIFF
--- a/charts/buildbuddy-enterprise/Chart.yaml
+++ b/charts/buildbuddy-enterprise/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise
 name: buildbuddy-enterprise
-version: 0.0.454 # Chart version
+version: 0.0.455 # Chart version
 appVersion: 2.264.0 # Version of deployed app
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise/values.yaml
+++ b/charts/buildbuddy-enterprise/values.yaml
@@ -393,7 +393,8 @@ config:
   #   client_id: MY_CLIENT_ID
   #   client_secret: MY_CLIENT_SECRET
   remote_execution:
-    enable_remote_exec: false
+    enable_remote_exec: false # Set to true to enable remote build execution (RBE)
+    use_measured_task_sizes: true # Enable auto-sizing for tasks
 
 grafana:
   enabled: false


### PR DESCRIPTION
Should be safe now that https://github.com/buildbuddy-io/buildbuddy/pull/12003 is released