### PR TITLE
Cache Proxy: add `app: <fullname>` label to deployment pods and selector

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.3 # Chart version
+version: 0.0.4 # Chart version
 appVersion: 2.261.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     {{- .Values.strategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
+      app: {{ include "buildbuddy.fullname" . }}
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   {{- if .Values.minReadySeconds }}
@@ -31,6 +32,7 @@ spec:
         {{- .Values.extraPodAnnotations | toYaml | nindent 8 }}
         {{- end }}
       labels:
+        app: {{ include "buildbuddy.fullname" . }}
         app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
Adds an `app` label matching the chart fullname to both the cache-proxy pod template and the Deployment's `matchLabels` selector. This makes the pods discoverable via the common `app=<name>` selector convention that we use for kubernetes-based discovery of distributed cache peers, in addition to the existing `app.kubernetes.io/name` / `app.kubernetes.io/instance` selectors that the chart's Service uses.

Worth noting that `selector.matchLabels` is immutable on an existing Deployment, so upgrading a release that was previously installed without this label will require deleting and recreating the Deployment. New installs are unaffected.