### PR TITLE
Cache Proxy: unset `--distributed_cache.cluster_size`

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.4 # Chart version
+version: 0.0.5 # Chart version
 appVersion: 2.261.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/values.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/values.yaml
@@ -112,7 +112,6 @@ config:
       root_directory: /buildbuddy/pebble_disk_cache/
     distributed_cache:
       listen_addr: 0.0.0.0:5151
-      cluster_size: 1
       # Automatically discover peer cache-proxy pods via the Kubernetes API.
       # Requires RBAC (see rbac.create / serviceAccount.create above).
       kubernetes_discovery: true


### PR DESCRIPTION
This prevents bootstrapping new deployments.