### PR TITLE
Remove unused MY_NODENAME env var from Helm chart.

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/templates/deployment.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/deployment.yaml
@@ -104,10 +104,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: MY_NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: K8S_POD_UID
               valueFrom:
                 fieldRef:

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -101,10 +101,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: MY_NODENAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
             - name: K8S_POD_UID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This env var is not used by our code so there's no reason to set it.