### PR TITLE
Convert cache-proxy chart to a StatefulSet with parallel pod management

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.5 # Chart version
+version: 0.0.6 # Chart version
 appVersion: 2.266.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/templates/rbac.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/rbac.yaml
@@ -25,7 +25,7 @@ rules:
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["statefulsets"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/buildbuddy-enterprise-cache-proxy/templates/statefulset.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "buildbuddy.fullname" . }}
   labels:
@@ -12,8 +12,10 @@ metadata:
     {{- end }}
 spec:
   replicas: {{ .Values.replicas | default 1 }}
-  strategy:
-    {{- .Values.strategy | toYaml | nindent 4 }}
+  serviceName: {{ include "buildbuddy.fullname" . }}-headless
+  podManagementPolicy: Parallel
+  updateStrategy:
+    {{- .Values.updateStrategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
       app: {{ include "buildbuddy.fullname" . }}

--- a/charts/buildbuddy-enterprise-cache-proxy/values.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/values.yaml
@@ -51,12 +51,12 @@ service:
   # externalMetricsPort: 9090
   # annotations: {}
 
-## Custom deployment strategy.
-strategy:
+## Custom StatefulSet update strategy.
+updateStrategy:
   type: RollingUpdate
 #   rollingUpdate:
-#     maxSurge: 1
-#     maxUnavailable: 0
+#     maxUnavailable: 1
+#     partition: 0
 
 podDisruptionBudget:
   enabled: true


### PR DESCRIPTION
Switches the buildbuddy-enterprise-cache-proxy chart from a Deployment to a StatefulSet so that pods get stable identities, which lines up better with the distributed-cache layer's peer discovery. Pod management policy is set to Parallel so rollouts and scale-ups don't have to wait for each pod to become Ready before starting the next one — the proxies don't depend on ordered startup. The Deployment-style `strategy` value is renamed to `updateStrategy` (with the rolling-update fields adjusted to match StatefulSet semantics), and the peer-discovery RBAC role is updated to grant `get` on `statefulsets` instead of `replicasets`.