### PR TITLE
cache-proxy: lift ingress body limit

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.8 # Chart version
+version: 0.0.9 # Chart version
 appVersion: 2.269.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/README.md
+++ b/charts/buildbuddy-enterprise-cache-proxy/README.md
@@ -55,6 +55,7 @@ Some common ones:
 | `cacheTarget`                                 | Upstream BuildBuddy cache the proxy sits in front of                 | `grpcs://remote.buildbuddy.io`                                   |
 | `resources`                                   | Pod CPU/memory requests and limits                                   | `4 CPU / 16Gi`                                                   |
 | `config`                                      | The `config.yaml` contents passed to the cache proxy                 | See [values.yaml](./values.yaml)                                 |
+| `ingress.annotations`                         | Extra annotations merged into the cache-proxy gRPC Ingress           | `proxy-body-size: "0"`                                           |
 | `rbac.create`                                 | Create the Role/RoleBinding used for Kubernetes peer discovery       | `true`                                                           |
 | `serviceAccount.create`                       | Create the ServiceAccount used by cache-proxy pods                   | `true`                                                           |
 | `podDisruptionBudget.enabled`                 | Enable a PodDisruptionBudget                                         | `true`                                                           |

--- a/charts/buildbuddy-enterprise-cache-proxy/values.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/values.yaml
@@ -97,7 +97,8 @@ ingress:
   ## Override the TLS secret name. Defaults to "<release>-grpc-tls".
   # grpcTlsSecretName: ""
   ## Extra annotations merged into the Ingress.
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
 
 # NOTE: These act as the default values for the config.yaml file read by the
 # cache-proxy. You can override the config object just like any Helm template


### PR DESCRIPTION
Large binary outputs are often subjected to CDC. When that happens,
the chunks are usually transferred using BatchUploadBlob rpc instead
of the traditional ByteStream. In dirtools, we set the size limit for
batch requests to be 2MB (used to be 4MB in the past). However, the
current nginx ingress has a size limit of 1MB, thus result in users
getting 413 error when uploading a large binary output to the server
through our proxy.

Disable the nginx body-size check by default so that FastCDC-chunked
uploads are not rejected by ingress body-size limits. Bump the chart
version so the packaged chart carries the fix.