### PR TITLE
cache-proxy: disable JWT reparsing

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.22 # Chart version
+version: 0.0.23 # Chart version
 appVersion: 2.281.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/README.md
+++ b/charts/buildbuddy-enterprise-cache-proxy/README.md
@@ -53,6 +53,7 @@ Some common ones:
 | `image.tag`                                   | Container image tag                                                  | `enterprise-v2.281.0`                                            |
 | `replicas`                                    | Number of cache-proxy replicas                                       | `3`                                                              |
 | `cacheTarget`                                 | Upstream BuildBuddy cache the proxy sits in front of                 | `grpcs://remote.buildbuddy.io`                                   |
+| `config.auth.reparse_jwts`                    | Disable process-local JWT reparsing for remote-authenticated proxies | `false`                                                          |
 | `resources`                                   | Pod CPU/memory requests and limits                                   | `4 CPU / 16Gi`                                                   |
 | `config`                                      | The `config.yaml` contents passed to the cache proxy                 | See [values.yaml](./values.yaml)                                 |
 | `ingress.annotations`                         | Extra annotations merged into the cache-proxy gRPC Ingress           | `proxy-body-size: "0"`                                           |

--- a/charts/buildbuddy-enterprise-cache-proxy/values.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/values.yaml
@@ -134,6 +134,10 @@ config:
       # of HMAC HS256. Requires the upstream app to be configured with
       # auth.jwt_es256_private_key.
       use_es256_jwts: true
+    # Do not reparse JWTs using process-local signing keys; cache proxies
+    # should rely on remote auth claims, especially when talking to
+    # BuildBuddy Cloud.
+    reparse_jwts: false
   ssl:
     enable_ssl: false
 


### PR DESCRIPTION
Fix BuildBuddy Cloud cache-proxy deployments that can reject local
cache writes after remote auth mints an ES256 JWT. This is needed
because JWT reparsing verifies those remote-auth tokens with the proxy
process-local signing keys instead of the remote auth key provider,
which can reject otherwise valid Cloud credentials with errors such as
incorrect key signing method: ES256.

Set auth.reparse_jwts to false in the cache-proxy chart defaults so
the proxy relies on remote-authenticated claims instead of local JWT
reverification. Document the default and bump the chart version for
the rendered config change.
