### PR TITLE
Set the `SYS_MEMORY_BYTES` and `SYS_MILLICPU` environment variables in the Cache Proxy Helm chart

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.24 # Chart version
+version: 0.0.25 # Chart version
 appVersion: 2.283.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/templates/statefulset.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/statefulset.yaml
@@ -110,6 +110,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
+            - name: SYS_MEMORY_BYTES
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: SYS_MILLICPU
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
           {{- if .Values.extraEnvVars }}
             {{- .Values.extraEnvVars | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
This will make us render the Proxy's CPU and memory allocation in the UI correctly (server/client code is [here](https://github.com/buildbuddy-io/buildbuddy/pull/12609)).

Related issues: https://github.com/buildbuddy-io/buildbuddy-internal/issues/7702