### PR TITLE
cache-proxy: add deployment guidance

### DIFF
--- a/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Enterprise Cache Proxy
 name: buildbuddy-enterprise-cache-proxy
-version: 0.0.28 # Chart version
+version: 0.0.29 # Chart version
 appVersion: 2.287.0 # Version of deployed cache proxy
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-enterprise-cache-proxy/README.md
+++ b/charts/buildbuddy-enterprise-cache-proxy/README.md
@@ -26,6 +26,34 @@ deployment on a [Kubernetes](https://kubernetes.io/) cluster using the
 
 This chart runs the Cache Proxy using BuildBuddy-recommended settings.
 
+## Deployment guidance
+
+Cache Proxy pods form a distributed cache. Consistent hashing assigns cached
+artifacts to the running pods, and reads and writes are routed to the pod that
+owns each artifact. Prefer fewer, larger proxy pods to reduce overhead, while
+keeping enough replicas and failure-domain spread for high availability.
+
+As a starting point, provision these totals across all proxy pods:
+
+- 1 proxy CPU for every 20-30 executor CPUs.
+- 1 GB of proxy memory for every 4-5 GB of executor memory.
+
+For example, a deployment with 1,000 executor CPUs and 2 TB of executor memory
+should start with about 33-50 total proxy CPUs and 400-500 GB of total proxy
+memory. Divide those totals across the proxy replicas. Monitor resource
+utilization and tune these values for your cache traffic and enabled features.
+
+Store proxy data on local SSD-backed storage. The chart's default `emptyDir`
+volume and the optional `cacheProxyDataVolumeHostPath` only select how storage
+is mounted; neither guarantees that the underlying node storage is an SSD.
+Schedule proxies onto appropriately configured nodes and spread replicas across
+failure domains.
+
+Deploying proxies and executors in the same cluster lets the executor pool
+autoscale while keeping cache traffic within the cluster. See the
+[Cache Proxy documentation](https://www.buildbuddy.io/docs/enterprise-proxy)
+for complete deployment and configuration guidance.
+
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:

--- a/charts/buildbuddy-enterprise-cache-proxy/templates/NOTES.txt
+++ b/charts/buildbuddy-enterprise-cache-proxy/templates/NOTES.txt
@@ -4,6 +4,18 @@ The cache proxy is a caching layer that sits in front of your BuildBuddy
 remote cache, serving frequently-requested blobs locally and reducing
 round-trips to the upstream cache.
 
+Deployment reminders:
+  * Proxies form a distributed, consistent-hash cache. Prefer fewer, larger
+    proxies while keeping enough replicas for high availability.
+  * Across all proxy pods, start with 1 proxy CPU per 20-30 executor CPUs and 1
+    GB of proxy memory per 4-5 GB of executor memory, then monitor and tune.
+  * Use local SSD-backed storage. emptyDir and hostPath do not guarantee SSDs.
+  * Run proxies and executors in the same cluster to keep cache traffic local
+    as executors autoscale.
+
+For complete deployment guidance:
+    https://www.buildbuddy.io/docs/enterprise-proxy
+
 If you have any questions - join our Slack channel at:
     https://slack.buildbuddy.io/
 

--- a/charts/buildbuddy-enterprise-cache-proxy/values.yaml
+++ b/charts/buildbuddy-enterprise-cache-proxy/values.yaml
@@ -8,7 +8,9 @@ image:
   tag: enterprise-v2.287.0
   imagePullPolicy: IfNotPresent
 
-## The number of cache-proxy replicas to run.
+## The number of cache-proxy replicas to run. Cache proxies use consistent
+## hashing to distribute cached artifacts across the running pods. Prefer fewer,
+## larger proxies while keeping enough replicas for high availability.
 replicas: 3
 
 ## The upstream BuildBuddy cache that this proxy sits in front of.
@@ -25,8 +27,13 @@ cacheTarget: grpcs://remote.buildbuddy.io
 #     operator: Equal
 #     value: cache-proxy
 
-## Default resources. Cache proxies are memory-hungry — size to fit your
-## working set.
+## Per-pod resources. As a starting point, allocate a total of 1 proxy CPU per
+## 20-30 executor CPUs and 1 GB of proxy memory per 4-5 GB of executor memory,
+## divided across all proxy replicas. For 1,000 executor CPUs and 2 TB of
+## executor memory, this is about 33-50 total proxy CPUs and 400-500 GB of total
+## proxy memory. Monitor utilization and tune for your cache traffic and enabled
+## features. See the deployment guide:
+## https://www.buildbuddy.io/docs/enterprise-proxy
 resources:
   limits:
     cpu: "4"
@@ -110,9 +117,9 @@ config:
   cache_proxy:
     proxy_type: "customer"
     # API key the cache proxy uses to authenticate to the upstream BuildBuddy
-    # cache/app. Set this to an executor-enabled API key. The remote_cache,
-    # app_target, and remote_hit_tracker fields are auto-populated from
-    # .Values.cacheTarget.
+    # cache/app. Set this to a Cache proxy key, not an executor-enabled API key.
+    # The remote_cache, app_target, and remote_hit_tracker fields are
+    # auto-populated from .Values.cacheTarget.
     # api_key: "YOUR_API_KEY"
   cache:
     max_size_bytes: 10000000000 # 10 GB
@@ -156,7 +163,10 @@ extraInitContainers: []
 extraContainers: []
 
 ## Path on the node to mount the 'cache-proxy-data' volume. If unset, an
-## emptyDir is used (data is lost on pod restart).
+## emptyDir is used (data is lost when the pod is removed or rescheduled). Use
+## local SSD-backed storage for proxy data. Neither emptyDir nor hostPath
+## guarantees that the underlying node storage is an SSD; schedule proxies onto
+## appropriately configured nodes.
 # cacheProxyDataVolumeHostPath: ""
 
 ## Additional volumes and mounts

--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.454 # Chart version
+version: 0.0.455 # Chart version
 appVersion: 2.202.0 # Version of deployed executor
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/README.md
+++ b/charts/buildbuddy-executor/README.md
@@ -134,6 +134,15 @@ its in-cluster gRPC Service. An explicit `config.executor.cache_target` takes
 precedence over the generated target. The cache proxy must use its own Cache
 proxy key rather than the executor-enabled API key.
 
+Running proxies and executors in the same cluster keeps cache traffic local
+while the executor pool autoscales. As a starting point, allocate 1 proxy CPU per
+20-30 executor CPUs and 1 GB of proxy memory per 4-5 GB of executor memory,
+measured across all proxy pods. Prefer fewer, larger proxy pods while preserving
+high availability, and use local SSD-backed proxy storage. Monitor utilization
+and tune for your workload. See the
+[Cache Proxy documentation](https://www.buildbuddy.io/docs/enterprise-proxy) for
+complete deployment guidance.
+
 ```yaml
 config:
   executor:


### PR DESCRIPTION
Cache Proxy operators currently have to ask support how to choose
storage, replica sizing, and resources because the chart exposes the
settings without operational context.

Add the sizing ratios, local SSD caveat, distributed-cache topology,
and same-cluster autoscaling benefit to the chart README, values, and
install notes. Point the executor chart's bundled-proxy example at the
same guidance, correct the API key wording, and bump both affected
chart versions.
