### PR TITLE
executor: add Firecracker values example

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.464 # Chart version
+version: 0.0.465 # Chart version
 appVersion: 2.202.0 # Version of deployed executor
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.459 # Chart version
+version: 0.0.460 # Chart version
 appVersion: 2.202.0 # Version of deployed executor
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/README.md
+++ b/charts/buildbuddy-executor/README.md
@@ -127,6 +127,27 @@ config:
     api_key: "YOUR_EXECUTOR_ENABLED_API_KEY"
 ```
 
+### Example Firecracker executor configuration
+
+[`values-firecracker.yaml`](values-firecracker.yaml) configures a
+three-replica, Firecracker-only executor deployment with local snapshot
+sharing. Before installing it, provision at least three Linux nodes that expose
+`/dev/kvm`, label each node, verify the configured path is backed by its local
+SSD, and replace the API key placeholder with an executor-enabled API key.
+Download the values file before installing the chart:
+
+```bash
+kubectl label node <node-name> buildbuddy.io/kvm=true
+curl --fail --location \
+  --output values-firecracker.yaml \
+  https://raw.githubusercontent.com/buildbuddy-io/buildbuddy-helm/master/charts/buildbuddy-executor/values-firecracker.yaml
+helm install my-release buildbuddy/buildbuddy-executor \
+  --values ./values-firecracker.yaml
+```
+
+Review the example's CPU, memory, node-local storage, task IP range, and local
+cache sizes for your executor nodes and network before deploying it.
+
 ### Example deploy a cache proxy with the executors
 
 Enable the bundled cache-proxy chart to automatically point the executors at

--- a/charts/buildbuddy-executor/values-firecracker.yaml
+++ b/charts/buildbuddy-executor/values-firecracker.yaml
@@ -1,0 +1,90 @@
+# Example values for running a Firecracker-only BuildBuddy Executor deployment.
+#
+# The Kubernetes nodes selected for this deployment must run Linux, support
+# hardware virtualization (or nested virtualization), and expose /dev/kvm.
+# Each replica requires a separate labeled node with local SSD storage. The
+# 1.15TB cache size below assumes at least 1.6TB of usable local SSD and leaves
+# headroom for workspaces, snapshots, and filesystem overhead. Adjust it for
+# the actual usable capacity, and verify the configured path is backed by the
+# mounted SSD before installing.
+
+replicas: 3
+
+# Label each compatible node before installing, for example:
+# kubectl label node <node-name> buildbuddy.io/kvm=true
+nodeSelector:
+  kubernetes.io/os: linux
+  buildbuddy.io/kvm: "true"
+
+# This label is selected by the required pod anti-affinity below.
+extraPodLabels:
+  buildbuddy.io/firecracker-executor: "true"
+
+# Keep executors on separate nodes so that they do not share a node-local
+# executor data directory or contend for the same KVM and network resources.
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            buildbuddy.io/firecracker-executor: "true"
+        topologyKey: kubernetes.io/hostname
+
+# With one executor per node, allow an old pod to stop before its replacement
+# is scheduled so that three-replica rolling updates cannot deadlock.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+
+resources:
+  requests:
+    cpu: "21"
+    memory: 78Gi
+  limits:
+    cpu: "21"
+    memory: 78Gi
+
+# Store executor data on node-local SSD. Verify this path is backed by the SSD
+# on every selected executor node before installing.
+executorDataVolumeHostPath: "/mnt/disks/local/0/buildbuddy"
+
+config:
+  executor:
+    app_target: "grpcs://remote.buildbuddy.io:443"
+    api_key: "YOUR_EXECUTOR_ENABLED_API_KEY"
+
+    # This example enables only Firecracker. To run a mixed OCI and Firecracker
+    # deployment, set enable_oci to true and select Firecracker per action with
+    # the execution property workload-isolation-type=firecracker.
+    enable_oci: false
+    enable_firecracker: true
+
+    # Bound the file cache so workspaces, snapshots, and filesystem overhead
+    # retain node-local SSD headroom. Adjust this for the actual usable capacity.
+    local_cache_size_bytes: 1_150_000_000_000 # 1.15TB
+
+    # Firecracker allocates guest networks from this IPv4 /16. Replace this if
+    # it overlaps any node, pod, service, VPC, VPN, or corporate network.
+    task_ip_range: "192.168.0.0/16"
+
+    # Reserve memory for mmap-backed Firecracker snapshot files. This is
+    # subtracted from schedulable task memory.
+    mmap_memory_bytes: 10_000_000_000 # 10GB
+
+    # Remote snapshot sharing additionally allows executors to exchange
+    # snapshots through the remote cache, at the cost of extra cache usage.
+    # enable_remote_snapshot_sharing: true
+
+# The executor chart automatically runs the container as privileged when
+# Firecracker is enabled. Mount the host's KVM device into the pod as well.
+extraVolumes:
+  - name: dev-kvm
+    hostPath:
+      path: /dev/kvm
+      type: CharDevice
+
+extraVolumeMounts:
+  - name: dev-kvm
+    mountPath: /dev/kvm

--- a/charts/buildbuddy-executor/values-firecracker.yaml
+++ b/charts/buildbuddy-executor/values-firecracker.yaml
@@ -1,0 +1,104 @@
+# Example values for running a Firecracker-only BuildBuddy Executor deployment.
+#
+# The Kubernetes nodes selected for this deployment must run Linux, support
+# hardware virtualization (or nested virtualization), and expose /dev/kvm.
+# Each replica requires a separate labeled node with at least 1.6TB of local
+# SSD storage. Verify the node-local storage path is backed by the mounted SSD
+# before installing.
+
+replicas: 3
+
+# Label each compatible node before installing, for example:
+# kubectl label node <node-name> buildbuddy.io/kvm=true
+nodeSelector:
+  kubernetes.io/os: linux
+  buildbuddy.io/kvm: "true"
+
+extraPodLabels:
+  buildbuddy.io/firecracker-executor: "true"
+
+# Keep executors on separate nodes so that they do not share a node-local
+# executor data directory or contend for the same KVM and network resources.
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            buildbuddy.io/firecracker-executor: "true"
+        topologyKey: kubernetes.io/hostname
+
+# With one executor per node, allow an old pod to stop before its replacement
+# is scheduled so that three-replica rolling updates cannot deadlock.
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 0
+    maxUnavailable: 1
+
+resources:
+  requests:
+    cpu: "21"
+    memory: 78Gi
+  limits:
+    cpu: "21"
+    memory: 78Gi
+
+# Store executor data on node-local SSD. Verify this path is backed by the SSD
+# on every selected executor node before installing.
+executorDataVolumeHostPath: "/mnt/disks/local/0/buildbuddy"
+
+config:
+  executor:
+    app_target: "grpcs://remote.buildbuddy.io:443"
+    api_key: "YOUR_EXECUTOR_ENABLED_API_KEY"
+
+    # This example configures a Firecracker-only executor deployment. To run a
+    # mixed OCI and Firecracker deployment instead, set enable_oci to true, set
+    # default_isolation_type to "oci", and select Firecracker per action with
+    # the execution property workload-isolation-type=firecracker.
+    enable_oci: false
+    enable_firecracker: true
+    default_isolation_type: "firecracker"
+
+    # Reuse prepared VM networks to reduce per-action setup overhead. A value
+    # of -1 selects the executor's recommended pool size.
+    firecracker_network_pool_size: -1
+
+    # Store converted Firecracker ext4 images in the size-bounded local file
+    # cache rather than the unbounded image directory under the build root.
+    # This value caps file-cache contents; it does not describe workspace
+    # capacity.
+    local_cache_store_ext4_images: true
+    local_cache_size_bytes: 1_150_000_000_000 # 1.15TB
+
+    # Workspace capacity is separate from the file-cache limit. This explicit
+    # limit keeps the 300GB workspace budget plus the 1.15TB cache below the
+    # documented 1.6TB minimum, leaving space for snapshots and filesystem
+    # overhead. Adjust both limits together if the local SSD size changes.
+    disk_bytes: 300_000_000_000 # 300GB
+
+    # Firecracker allocates guest networks from this IPv4 /16. Replace this if
+    # it overlaps any node, pod, service, VPC, VPN, or corporate network.
+    task_ip_range: "192.168.0.0/16"
+
+    # Share local snapshots between recycled runners on this executor. The
+    # mmap memory reservation is subtracted from schedulable task memory.
+    enable_local_snapshot_sharing: true
+    firecracker_enable_balloon: true
+    mmap_memory_bytes: 10_000_000_000 # 10GB
+
+    # Remote snapshot sharing additionally allows executors to exchange
+    # snapshots through the remote cache, at the cost of extra cache usage.
+    # enable_remote_snapshot_sharing: true
+
+# The executor chart automatically runs the container as privileged when
+# Firecracker is enabled. Mount the host's KVM device into the pod as well.
+extraVolumes:
+  - name: dev-kvm
+    hostPath:
+      path: /dev/kvm
+      type: CharDevice
+
+extraVolumeMounts:
+  - name: dev-kvm
+    mountPath: /dev/kvm


### PR DESCRIPTION
Self-hosted Firecracker users must assemble the required KVM, local SSD,
networking, and snapshot settings themselves because the chart does not
provide a production-shaped example.

Add a three-replica, Firecracker-only values file with production-shaped
CPU, memory, local cache, KVM, networking, and node scheduling. Enable only
Firecracker and rely on the executor's isolation ordering and current defaults
for network pooling, ext4 image caching, local snapshot sharing, and memory
ballooning. Document that operators must verify the host path is backed by
local SSD, and keep the chart's existing values and `DirectoryOrCreate`
host-path behavior unchanged.

The example intentionally omits a shutdown-duration override because the
current production deployment uses the executor and Kubernetes defaults.

Tests:

- `helm lint --strict charts/buildbuddy-executor`
- `helm lint --strict charts/buildbuddy-executor -f charts/buildbuddy-executor/values-firecracker.yaml`
- Rendered and inspected both the default host-path behavior and the full
  Firecracker Deployment and executor config
- Packaged the chart and verified the example is included
- Local Kind, using the same Firecracker settings with local resource
  overrides: three executors registered, and a cold Firecracker action
  succeeded
- A `recycle-runner=true` action saved a local snapshot. The forced resume
  reached Firecracker snapshot load, but Firecracker 1.15.1 then panicked
  with `InvalidAvailIdx`; the action failed with `error resuming VM`. The
  same failure reproduced with PCI disabled, the production Ubuntu image,
  and ext4-backed local storage, so snapshot resume is not confirmed on the
  local workstation.
