### PR TITLE
executor: persist generated host IDs

### DIFF
--- a/charts/buildbuddy-executor/Chart.yaml
+++ b/charts/buildbuddy-executor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: BuildBuddy Executor
 name: buildbuddy-executor
-version: 0.0.460 # Chart version
+version: 0.0.461 # Chart version
 appVersion: 2.202.0 # Version of deployed executor
 keywords:
   - buildbuddy

--- a/charts/buildbuddy-executor/README.md
+++ b/charts/buildbuddy-executor/README.md
@@ -91,6 +91,8 @@ The following table lists the configurable parameters of the BuildBuddy Open Sou
 | `extraInitContainers`         | Additional init containers                                                                                                                                                                                                                                                                                                                        | `[]`                                                                                                                               |
 | `extraContainers`             | Additional containers                                                                                                                                                                                                                                                                                                                             | `[]`                                                                                                                               |
 | `customExecutorCommand`       | Custom command for running the executor                                                                                                                                                                                                                                                                                                           | `null`                                                                                                                             |
+| `executorDataVolumeHostPath`  | Optional node hostPath for the executor cache and build-data volume mounted at `/buildbuddy`. Enabling it adds required one-executor-per-node anti-affinity.                                                                                                                                                                                       | `null` (`emptyDir`)                                                                                                                 |
+| `executorMetadataVolume`      | Kubernetes VolumeSource for generated executor host-ID metadata. The default is a release-specific node hostPath and adds required one-executor-per-node anti-affinity.                                                                                                                                                                            | `null` (managed node `hostPath`)                                                                                                    |
 | `priorityClassName`           | Optional Kubernetes priority class name assigned to executor pods                                                                                                                                                                                                                                                                                 | `null`                                                                                                                             |
 | `dnsConfig`                   | Pod DNS configuration (e.g. `options.ndots`, `searches`, `nameservers`)                                                                                                                                                                                                                                                                             | `null`                                                                                                                             |
 | `dnsPolicy`                   | Pod DNS policy (`ClusterFirst`, `Default`, `None`, etc.)                                                                                                                                                                                                                                                                                          | `null`                                                                                                                             |
@@ -125,6 +127,52 @@ config:
     app_target: "grpcs://remote.buildbuddy.io:443"
     local_cache_size_bytes: 50000000000 # 50GB
     api_key: "YOUR_EXECUTOR_ENABLED_API_KEY"
+```
+
+### Executor identity and metadata persistence
+
+Executor registrations have distinct host, pod, and process identities:
+
+- The executor generates a random host ID and stores it in
+  `/buildbuddy/metadata/host_id`. BuildBuddy uses this ID for cache affinity.
+- `MY_HOSTNAME` and `MY_NODE_NAME` contain the Kubernetes node name. The
+  scheduler registration log correlates this hostname with the host ID and
+  executor ID.
+- `MY_POD_NAME` contains the Kubernetes pod name for monitoring and log
+  correlation.
+- The executor ID remains a random UUID generated on every process start, so a
+  container restart in the same pod creates a distinct executor registration.
+
+By default, `executorMetadataVolume` mounts a release-specific node `hostPath`
+at `/buildbuddy/metadata`. A replacement pod on the same node reuses that
+node's generated host ID. A pod scheduled on another node uses the ID already
+stored on that node, or generates a new one. Replacing or deleting the node
+also removes this identity unless the host path is retained outside the node.
+
+The metadata volume is separate from `executor-data`, which remains an
+`emptyDir` by default. This avoids making the executor cache and build data
+node-persistent merely to preserve the host ID. If the legacy
+`executorDataVolumeHostPath` is configured, the metadata volume defaults to
+its existing `metadata` subdirectory so upgrades keep the stored host ID.
+
+Multiple executor processes must not use the same metadata directory or host
+ID. Whenever the effective metadata volume or `executor-data` is a node
+`hostPath`, the chart adds required pod anti-affinity on
+`kubernetes.io/hostname`, allowing at most one executor pod from the release
+on each node. Rolling updates use zero surge and replace one executor at a time
+by default so the new pod can schedule after the old pod leaves its node. An
+explicit nonzero `strategy.rollingUpdate.maxUnavailable` is preserved. The
+default three replicas therefore require three eligible Kubernetes nodes;
+otherwise some executor pods remain pending.
+
+Set `executorMetadataVolume` to any Kubernetes VolumeSource to customize the
+storage. A custom source must be writable and exclusive to one replica; a
+shared PVC is not safe for multiple executor processes. For ephemeral per-pod
+identity and no automatic one-per-node constraint, use:
+
+```yaml
+executorMetadataVolume:
+  emptyDir: {}
 ```
 
 ### Example deploy a cache proxy with the executors

--- a/charts/buildbuddy-executor/templates/deployment.yaml
+++ b/charts/buildbuddy-executor/templates/deployment.yaml
@@ -1,3 +1,25 @@
+{{- $metadataVolume := .Values.executorMetadataVolume -}}
+{{- $metadataUsesHostPath := or (not $metadataVolume) (hasKey $metadataVolume "hostPath") -}}
+{{- $usesNodeHostPath := or $metadataUsesHostPath .Values.executorDataVolumeHostPath -}}
+{{- $strategy := deepCopy .Values.strategy -}}
+{{- if and $usesNodeHostPath (eq (get $strategy "type") "RollingUpdate") -}}
+{{- $rollingUpdate := deepCopy (default (dict) (get $strategy "rollingUpdate")) -}}
+{{- $_ := set $rollingUpdate "maxSurge" 0 -}}
+{{- $maxUnavailable := toString (get $rollingUpdate "maxUnavailable") -}}
+{{- if or (not (hasKey $rollingUpdate "maxUnavailable")) (eq $maxUnavailable "0") (eq $maxUnavailable "0%") -}}
+{{- $_ := set $rollingUpdate "maxUnavailable" 1 -}}
+{{- end -}}
+{{- $_ := set $strategy "rollingUpdate" $rollingUpdate -}}
+{{- end -}}
+{{- $affinity := deepCopy (default (dict) .Values.affinity) -}}
+{{- if $usesNodeHostPath -}}
+{{- $podAntiAffinity := deepCopy (default (dict) (get $affinity "podAntiAffinity")) -}}
+{{- $required := default (list) (get $podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
+{{- $selectorLabels := dict "app.kubernetes.io/name" (include "buildbuddy.name" .) "app.kubernetes.io/instance" .Release.Name -}}
+{{- $term := dict "labelSelector" (dict "matchLabels" $selectorLabels) "topologyKey" "kubernetes.io/hostname" -}}
+{{- $_ := set $podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution" (append $required $term) -}}
+{{- $_ := set $affinity "podAntiAffinity" $podAntiAffinity -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -15,7 +37,7 @@ spec:
   replicas: {{ .Values.replicas | default 1 }}
   {{- end }}
   strategy:
-    {{- .Values.strategy | toYaml | nindent 4 }}
+    {{- $strategy | toYaml | nindent 4 }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "buildbuddy.name" . }}
@@ -49,9 +71,9 @@ spec:
       securityContext:
       {{- .Values.securityContext | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.affinity}}
+      {{- if $affinity }}
       affinity:
-        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- toYaml $affinity | nindent 8 }}
       {{- end }}
       {{- if .Values.nodeSelector}}
       nodeSelector:
@@ -107,10 +129,18 @@ spec:
             {{- .Values.resources | toYaml | nindent 12 }}
           {{- end }}
           env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: MY_HOSTNAME
               valueFrom:
                 fieldRef:
-                  fieldPath: status.podIP
+                  fieldPath: spec.nodeName
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: K8S_POD_UID
               valueFrom:
                 fieldRef:
@@ -170,6 +200,8 @@ spec:
               name: user-config-buildbuddy
             - mountPath: /buildbuddy/
               name: executor-data
+            - mountPath: /buildbuddy/metadata/
+              name: executor-metadata
             - mountPath: /config.yaml
               name: config
               subPath: config.yaml
@@ -206,6 +238,18 @@ spec:
             type: DirectoryOrCreate
           {{- else }}
           emptyDir: {}
+          {{- end }}
+        - name: executor-metadata
+          {{- if $metadataVolume }}
+          {{- $metadataVolume | toYaml | nindent 10 }}
+          {{- else }}
+          hostPath:
+            {{- if .Values.executorDataVolumeHostPath }}
+            path: {{ printf "%s/metadata" (trimSuffix "/" .Values.executorDataVolumeHostPath) | quote }}
+            {{- else }}
+            path: {{ printf "/var/lib/buildbuddy/executor-metadata/%s/%s" .Release.Namespace (include "buildbuddy.fullname" .) | quote }}
+            {{- end }}
+            type: DirectoryOrCreate
           {{- end }}
         - name: config
           secret:

--- a/charts/buildbuddy-executor/values.yaml
+++ b/charts/buildbuddy-executor/values.yaml
@@ -123,6 +123,7 @@ podDisruptionBudget:
 config:
   executor:
     # app_target: "grpcs://your.buildbuddy.install:443" # auto populated if deploying via buildbuddy-enterprise chart
+    metadata_directory: "/buildbuddy/metadata/"
     root_directory: "/buildbuddy/remotebuilds/"
     local_cache_directory: "/buildbuddy/filecache/"
     local_cache_size_bytes: 100000000000  # 100GB
@@ -164,8 +165,26 @@ extraInitContainers: []
 extraContainers: []
 
 ## Path on the node to mount 'executor-data' volume.
-## If not set, 'executor-data' will use emptyDir.
+## If not set, 'executor-data' will use emptyDir. Setting this also adds
+## required pod anti-affinity so at most one executor from this release can run
+## on each Kubernetes node.
 # executorDataVolumeHostPath: ""
+
+## Kubernetes VolumeSource for executor metadata, mounted at
+## /buildbuddy/metadata. The executor stores its generated host_id here.
+##
+## The default (null) uses a release-specific node hostPath under
+## /var/lib/buildbuddy/executor-metadata. When executorDataVolumeHostPath is
+## set, the default instead uses its existing metadata subdirectory to preserve
+## the stored host ID across upgrades.
+##
+## A hostPath metadata source automatically adds required pod anti-affinity so
+## at most one executor from this release can run on each Kubernetes node.
+## The default replicas therefore require the same number of schedulable nodes.
+## Custom non-hostPath sources must be writable and provide replica-exclusive
+## storage, or be used with a single replica. Set emptyDir: {} to opt out of
+## pod-replacement persistence and the automatic anti-affinity.
+executorMetadataVolume: null
 
 ## Path on the node to mount Podman 'containers-lib' volume,
 ## which is mounted to /var/lib/containers inside the Executor pod.

--- a/tests/buildbuddy_executor_identity_test.sh
+++ b/tests/buildbuddy_executor_identity_test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+chart="$repo_root/charts/buildbuddy-executor"
+values_file="$(mktemp)"
+trap 'rm -f "$values_file"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+  [[ "$haystack" == *"$needle"* ]] || fail "$description"
+}
+
+assert_not_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local description="$3"
+  [[ "$haystack" != *"$needle"* ]] || fail "$description"
+}
+
+render_deployment() {
+  helm template test "$chart" --show-only templates/deployment.yaml "$@"
+}
+
+render_config() {
+  helm template test "$chart" --show-only templates/config.yaml "$@" \
+    | awk '/^  config.yaml: / {print $2}' \
+    | base64 --decode
+}
+
+default_deployment="$(render_deployment)"
+assert_contains "$default_deployment" $'- name: MY_POD_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath: metadata.name' \
+  "default deployment should expose the pod name"
+assert_contains "$default_deployment" $'- name: MY_HOSTNAME\n              valueFrom:\n                fieldRef:\n                  fieldPath: spec.nodeName' \
+  "default registration hostname should use the node name"
+assert_contains "$default_deployment" $'- name: MY_NODE_NAME\n              valueFrom:\n                fieldRef:\n                  fieldPath: spec.nodeName' \
+  "default deployment should expose the node name"
+assert_contains "$default_deployment" $'- mountPath: /buildbuddy/metadata/\n              name: executor-metadata' \
+  "default deployment should mount executor metadata separately"
+assert_contains "$default_deployment" 'path: "/var/lib/buildbuddy/executor-metadata/default/test-buildbuddy-executor"' \
+  "default metadata should use a release-specific node hostPath"
+assert_contains "$default_deployment" 'topologyKey: kubernetes.io/hostname' \
+  "hostPath metadata should require one executor per node"
+assert_contains "$default_deployment" $'rollingUpdate:\n      maxSurge: 0\n      maxUnavailable: 1' \
+  "hostPath metadata should use a non-surging rolling update"
+
+default_config="$(render_config)"
+assert_contains "$default_config" 'metadata_directory: /buildbuddy/metadata/' \
+  "default config should store generated host IDs in the metadata volume"
+assert_not_contains "$default_config" 'host_id:' \
+  "default config should keep the executor-generated host ID"
+
+printf '%s\n' 'executorMetadataVolume:' '  emptyDir: {}' >"$values_file"
+ephemeral_deployment="$(render_deployment --values "$values_file")"
+assert_contains "$ephemeral_deployment" $'- name: executor-metadata\n          emptyDir: {}' \
+  "custom metadata VolumeSource should render unchanged"
+assert_not_contains "$ephemeral_deployment" 'topologyKey: kubernetes.io/hostname' \
+  "non-hostPath metadata should not force node anti-affinity"
+assert_not_contains "$ephemeral_deployment" 'maxSurge: 0' \
+  "non-hostPath metadata should keep the configured deployment strategy"
+
+printf '%s\n' 'executorMetadataVolume:' '  csi:' \
+  '    driver: metadata.csi.example' '    fsType: ext4' \
+  '    volumeAttributes:' '      purpose: executor-identity' >"$values_file"
+csi_deployment="$(render_deployment --values "$values_file")"
+assert_contains "$csi_deployment" $'csi:\n            driver: metadata.csi.example\n            fsType: ext4\n            volumeAttributes:\n              purpose: executor-identity' \
+  "nested custom metadata VolumeSource should render unchanged"
+assert_not_contains "$csi_deployment" 'topologyKey: kubernetes.io/hostname' \
+  "custom CSI metadata should not force node anti-affinity"
+
+printf '%s\n' 'executorMetadataVolume:' '  hostPath:' \
+  '    path: /mnt/executor-metadata' '    type: DirectoryOrCreate' \
+  'strategy:' '  type: RollingUpdate' '  rollingUpdate:' \
+  '    maxSurge: 2' '    maxUnavailable: 40%' \
+  'affinity:' '  nodeAffinity:' \
+  '    preferredDuringSchedulingIgnoredDuringExecution:' \
+  '      - weight: 1' '        preference:' '          matchExpressions:' \
+  '            - key: storage' '              operator: Exists' \
+  '  podAntiAffinity:' '    requiredDuringSchedulingIgnoredDuringExecution:' \
+  '      - labelSelector:' '          matchLabels:' \
+  '            workload: other' '        topologyKey: topology.kubernetes.io/zone' \
+  '    preferredDuringSchedulingIgnoredDuringExecution:' \
+  '      - weight: 10' '        podAffinityTerm:' '          labelSelector:' \
+  '            matchLabels:' '              workload: preferred' \
+  '          topologyKey: kubernetes.io/hostname' >"$values_file"
+merged_deployment="$(render_deployment --values "$values_file")"
+assert_contains "$merged_deployment" 'path: /mnt/executor-metadata' \
+  "custom hostPath metadata should render unchanged"
+assert_contains "$merged_deployment" 'nodeAffinity:' \
+  "generated anti-affinity should preserve node affinity"
+assert_contains "$merged_deployment" 'topologyKey: topology.kubernetes.io/zone' \
+  "generated anti-affinity should preserve required pod anti-affinity"
+assert_contains "$merged_deployment" 'workload: preferred' \
+  "generated anti-affinity should preserve preferred pod anti-affinity"
+assert_contains "$merged_deployment" 'app.kubernetes.io/instance: test' \
+  "hostPath metadata should append release anti-affinity"
+assert_contains "$merged_deployment" $'maxSurge: 0\n      maxUnavailable: 40%' \
+  "hostPath rollout should preserve explicit maxUnavailable"
+
+printf '%s\n' 'strategy:' '  type: Recreate' >"$values_file"
+recreate_deployment="$(render_deployment --values "$values_file")"
+assert_contains "$recreate_deployment" $'strategy:\n    type: Recreate' \
+  "hostPath metadata should preserve Recreate strategy"
+assert_not_contains "$recreate_deployment" 'rollingUpdate:' \
+  "Recreate strategy should not render rolling update options"
+
+printf '%s\n' 'executorMetadataVolume:' '  emptyDir: {}' >"$values_file"
+ephemeral_legacy_deployment="$(render_deployment --values "$values_file" \
+  --set executorDataVolumeHostPath=/var/lib/buildbuddy-executor)"
+assert_contains "$ephemeral_legacy_deployment" 'topologyKey: kubernetes.io/hostname' \
+  "executor-data hostPath should require one executor per node"
+
+legacy_deployment="$(render_deployment \
+  --set executorDataVolumeHostPath=/var/lib/buildbuddy-executor)"
+assert_contains "$legacy_deployment" 'path: /var/lib/buildbuddy-executor' \
+  "executorDataVolumeHostPath should keep rendering the executor-data hostPath"
+assert_contains "$legacy_deployment" 'path: "/var/lib/buildbuddy-executor/metadata"' \
+  "legacy hostPath should preserve its existing metadata directory"
+assert_contains "$legacy_deployment" 'topologyKey: kubernetes.io/hostname' \
+  "legacy node metadata should require one executor per node"
+
+echo "PASS: buildbuddy executor identity rendering"


### PR DESCRIPTION
Executor pods lose their generated host ID when a Deployment replaces
the pod because metadata currently lives in the executor-data emptyDir.
Persisting all of /buildbuddy to retain the ID also couples identity
to cache and build storage and can let colocated replicas share unsafe
process state.

Mount /buildbuddy/metadata from a dedicated, configurable VolumeSource,
defaulting to a release-scoped node hostPath. Reuse the existing
executorDataVolumeHostPath metadata directory when that legacy option
is set. Keep host IDs as generated UUIDs and executor IDs random per
process, while registering the node name as hostname and exposing
the pod name separately.

Require one executor per node and zero-surge rolling updates whenever
metadata or executor data uses hostPath. Document lifecycle and custom
volume exclusivity, and cover default, legacy, and custom sources in
render tests.
